### PR TITLE
implement submit flow for sign hotspot app links

### DIFF
--- a/src/features/home/homeTypes.ts
+++ b/src/features/home/homeTypes.ts
@@ -21,7 +21,15 @@ export type BurnRouteParam = {
 export type HomeStackParamList = {
   AccountsScreen: undefined
   AccountTokenScreen: { tokenType: TokenType }
-  AccountAssignScreen: undefined
+  AccountAssignScreen:
+    | undefined
+    | {
+        secureAccount?: {
+          mnemonic: string[]
+          keypair: { pk: string; sk: string }
+          address: string
+        }
+      }
   ConfirmPin: {
     action: 'payment'
   }

--- a/src/features/home/homeTypes.ts
+++ b/src/features/home/homeTypes.ts
@@ -36,7 +36,7 @@ export type HomeStackParamList = {
   SettingsNavigator: undefined
   AddNewContact: undefined
   LinkWallet: LinkWalletRequest
-  SignHotspot: SignHotspotRequest
+  SignHotspot: SignHotspotRequest & { submit?: boolean }
   AddNewAccountNavigator: undefined
   ReImportAccountNavigator:
     | undefined

--- a/src/features/onboarding/create/createAccountNavTypes.ts
+++ b/src/features/onboarding/create/createAccountNavTypes.ts
@@ -6,7 +6,7 @@ export type CreateAccountStackParamList = {
   AccountCreateStartScreen: undefined
   AccountCreatePassphraseScreen: undefined
   AccountEnterPassphraseScreen: undefined
-  AccountAssignScreen: undefined
+  AccountAssignScreen: undefined | { secureAccount?: SecureAccount }
   AccountCreatePinScreen:
     | {
         pinReset?: boolean

--- a/src/features/txnDelegatation/SignHotspot.tsx
+++ b/src/features/txnDelegatation/SignHotspot.tsx
@@ -1,7 +1,7 @@
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native'
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Linking } from 'react-native'
+import { ActivityIndicator, Linking } from 'react-native'
 import { AddGateway, Location, Transfer } from '@helium/react-native-sdk'
 import animalHash from 'angry-purple-tiger'
 import { useAsync } from 'react-async-hook'
@@ -11,6 +11,7 @@ import {
   SignHotspotResponse,
   createSignHotspotCallbackUrl,
 } from '@helium/wallet-link'
+import Toast from 'react-native-simple-toast'
 import Box from '../../components/Box'
 import SafeAreaBox from '../../components/SafeAreaBox'
 import Text from '../../components/Text'
@@ -20,21 +21,32 @@ import { useAccountStorage } from '../../storage/AccountStorageProvider'
 import AccountIcon from '../../components/AccountIcon'
 import { formatAccountAlias } from '../../utils/accountUtils'
 import { getKeypair } from '../../storage/secureStorage'
+import { useSubmitTxnMutation } from '../../generated/graphql'
+import { useColors } from '../../theme/themeHooks'
 
 type Route = RouteProp<HomeStackParamList, 'SignHotspot'>
 const SignHotspot = () => {
   const {
-    params: { token, addGatewayTxn, assertLocationTxn, transferHotspotTxn } = {
+    params: {
+      token,
+      addGatewayTxn,
+      assertLocationTxn,
+      transferHotspotTxn,
+      submit,
+    } = {
       token: '',
       addGatewayTxn: '',
       assertLocationTxn: '',
       transferHotspotTxn: '',
+      submit: false,
     },
   } = useRoute<Route>()
   const navigation = useNavigation<HomeNavigationProp>()
   const { t } = useTranslation()
   const [validated, setValidated] = useState<boolean>()
   const { accounts } = useAccountStorage()
+  const { surfaceContrastText } = useColors()
+  const [submitTxnMutation, { loading: submitLoading }] = useSubmitTxnMutation()
 
   const linkInvalid = useMemo(() => {
     return !addGatewayTxn && !assertLocationTxn && !transferHotspotTxn
@@ -91,6 +103,26 @@ const SignHotspot = () => {
   const handleLink = useCallback(async () => {
     if (!parsedToken) return
 
+    if (submit) {
+      // submitting signed transaction from hotspot app
+      const txn = assertLocationTxn || transferHotspotTxn
+      try {
+        if (!txn) throw new Error('no transaction')
+
+        await submitTxnMutation({
+          variables: {
+            address: parsedToken.address,
+            txn,
+          },
+        })
+        Toast.show(t('generic.submitSuccess'))
+      } catch (e) {
+        Toast.show(t('generic.somethingWentWrong'))
+      }
+      navigation.goBack()
+      return
+    }
+
     try {
       const ownerKeypair = await getKeypair(parsedToken.address || '')
 
@@ -144,11 +176,17 @@ const SignHotspot = () => {
       // Logger.error(e)
     }
   }, [
+    assertLocationTxn,
     callback,
     gatewayAddress,
     gatewayTxn,
     locationTxn,
+    navigation,
     parsedToken,
+    submit,
+    submitTxnMutation,
+    t,
+    transferHotspotTxn,
     transferTxn,
   ])
 
@@ -345,6 +383,7 @@ const SignHotspot = () => {
           backgroundColor="secondary"
           borderRadius="round"
           onPress={handleCancel}
+          disabled={submitLoading}
         >
           <Text variant="subtitle1" textAlign="center" color="primaryText">
             {t('generic.cancel')}
@@ -357,7 +396,9 @@ const SignHotspot = () => {
           justifyContent="center"
           borderRadius="round"
           onPress={handleLink}
-          disabled={!validated}
+          disabled={!validated || submitLoading}
+          flexDirection="row"
+          alignItems="center"
         >
           <Text
             variant="subtitle1"
@@ -366,6 +407,11 @@ const SignHotspot = () => {
           >
             {t('generic.confirm')}
           </Text>
+          {submitLoading && (
+            <Box marginLeft="s">
+              <ActivityIndicator color={surfaceContrastText} />
+            </Box>
+          )}
         </TouchableOpacityBox>
       </Box>
     </SafeAreaBox>

--- a/src/features/txnDelegatation/SignHotspot.tsx
+++ b/src/features/txnDelegatation/SignHotspot.tsx
@@ -23,6 +23,7 @@ import { formatAccountAlias } from '../../utils/accountUtils'
 import { getKeypair } from '../../storage/secureStorage'
 import { useSubmitTxnMutation } from '../../generated/graphql'
 import { useColors } from '../../theme/themeHooks'
+import * as Logger from '../../utils/logger'
 
 type Route = RouteProp<HomeStackParamList, 'SignHotspot'>
 const SignHotspot = () => {
@@ -106,6 +107,8 @@ const SignHotspot = () => {
     if (submit) {
       // submitting signed transaction from hotspot app
       const txn = assertLocationTxn || transferHotspotTxn
+      const txnObject = locationTxn || transferTxn
+
       try {
         if (!txn) throw new Error('no transaction')
 
@@ -113,10 +116,12 @@ const SignHotspot = () => {
           variables: {
             address: parsedToken.address,
             txn,
+            txnJson: JSON.stringify(txnObject),
           },
         })
         Toast.show(t('generic.submitSuccess'))
       } catch (e) {
+        Logger.error(e)
         Toast.show(t('generic.somethingWentWrong'))
       }
       navigation.goBack()

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -243,6 +243,8 @@ export default {
     testnet: 'Testnet',
     total: 'Total',
     tryAgain: 'Try Again',
+    somethingWentWrong: 'Something went wrong, please try again',
+    submitSuccess: 'Transaction Submit',
   },
   hntKeyboard: {
     enterAmount: 'Enter {{ticker}} Amount',


### PR DESCRIPTION
Allows passing of a signed assert or transfer txn with a flag of submit in order to submit the transaction in wallet app. The flow is as follows: 
1. Users in Hotspot app want to transfer or update location
2. They create and sign the transaction in Hotspot App
3. They pass the txn to the Wallet app via deeplink and the wallet app confirms and submits the transaction 