### PR TITLE
More import account fixes

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -68,6 +68,8 @@ export default {
       paste: 'Copy and paste your private key from the Helium Hotspot App.',
       inputPlaceholder: 'You private key...',
       error: 'Invalid Private Key',
+      exists:
+        'The account you\'re importing already exists as "{{alias}}". No further action is required.',
       body: 'You are importing a private key with the following public key.',
       action: 'Import Account',
     },


### PR DESCRIPTION
- now imports words directly instead of private key to preserve existing hotspot wallet words (no longer moves to 24 words)
- added a new error screen when trying to import an account that already exists