### PR TITLE
Fix typo in supportedCurrencies.ts for NZD

### DIFF
--- a/src/utils/supportedCurrencies.ts
+++ b/src/utils/supportedCurrencies.ts
@@ -24,7 +24,7 @@ export default {
   MYR: 'Malaysian Ringgit',
   NGN: 'Nigerian Naira',
   NOK: 'Norwegian Krone',
-  NZD: 'New Zealand Dolloar',
+  NZD: 'New Zealand Dollar',
   PHP: 'Philippine Peso',
   PKR: 'Pakistani Rupee',
   PLN: 'Polish Zloty',


### PR DESCRIPTION
Fix typo in NZD: 'New Zealand Dollar'