### PR TITLE
Fix Wallet Standard event handler

### DIFF
--- a/src/features/browser/walletStandard.js
+++ b/src/features/browser/walletStandard.js
@@ -413,9 +413,7 @@ try {
 }
 
 parent.addEventListener('wallet-standard:app-ready', function (event) {
-    window.ReactNativeWebView.postMessage(
-        JSON.stringify({ type: 'app-ready', event: event.data }),
-    )
+    event.detail.register(walletObj)
 })
 }`
 


### PR DESCRIPTION
From discussion with @ChewingGlass, if the Helium Wallet injection isn't ready by the time the app loads, the wallet won't get displayed. This is caused by improper handling of the `wallet-standard:app-ready` event, which is currently just logging the event. Instead, the handler needs to register the Standard Wallet.