### PR TITLE
Change NFT Transfer button texts to "Transfer Hotspot"

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -160,7 +160,7 @@ export default {
   collectablesScreen: {
     title: 'Collectables',
     metadata: 'Metadata',
-    transfer: 'Transfer',
+    transfer: 'Transfer Hotspot',
     transferComplete: 'NFT Transferred!',
     returnToCollectables: 'Return to Collectables',
     transferFee: '<b>Fee</b> <secondaryText> {{ amount }} SOL </secondaryText>',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -161,7 +161,7 @@ export default {
     title: 'Collectables',
     metadata: 'Metadata',
     transfer: 'Transfer Hotspot',
-    transferComplete: 'NFT Transferred!',
+    transferComplete: 'Hotspot Transferred!',
     returnToCollectables: 'Return to Collectables',
     transferFee: '<b>Fee</b> <secondaryText> {{ amount }} SOL </secondaryText>',
     transferingNftTitle: 'Transferring NFT...',


### PR DESCRIPTION
Change "Transfer" to "Transfer Hotspot" suggested to reduce the number of people potentially transferring their Hotspots during the claim process as a result of confusion.