### PR TITLE
fix: Cancel claim all transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ Follow the instructions for "React Native CLI Quickstart" found [here](https://r
   ```bash
   yarn
   ```
+- Fill out your env.sample with your values and rename it to `.env`. Set up a Mapbox account and generate a public and private key for the access token and download token environment variables.
+
+- Create a netrc file to authenticate with mapbox
+  ```bash
+  touch ~/.netrc
+  nano ~/.netrc
+  ```
+- Insert your mapbox authentication details
+  ```bash
+  machine api.mapbox.com
+   login mapbox
+   password <INSERT API TOKEN>
+  ```
 - Install Pods
   ```bash
   yarn pod-install

--- a/src/features/collectables/ClaimAllRewardsScreen.tsx
+++ b/src/features/collectables/ClaimAllRewardsScreen.tsx
@@ -40,7 +40,7 @@ const ClaimAllRewardsScreen = () => {
   const { showOKCancelAlert } = useAlert()
   const { anchorProvider } = useSolana()
   const showHNTConversionAlert = useCallback(async () => {
-    if (!anchorProvider || !hntSolConvertTransaction) return
+    if (!anchorProvider || !hntSolConvertTransaction) return false
 
     const decision = await showOKCancelAlert({
       title: t('browserScreen.insufficientSolToPayForFees'),
@@ -50,7 +50,7 @@ const ClaimAllRewardsScreen = () => {
       }),
     })
 
-    if (!decision) return
+    if (!decision) return false
     const signed = await anchorProvider.wallet.signTransaction(
       hntSolConvertTransaction,
     )
@@ -62,6 +62,7 @@ const ClaimAllRewardsScreen = () => {
       },
       'confirmed',
     )
+    return true
   }, [
     anchorProvider,
     hntSolConvertTransaction,
@@ -92,7 +93,11 @@ const ClaimAllRewardsScreen = () => {
       setClaimError(undefined)
       setRedeeming(true)
       if (!hasEnoughSol) {
-        await showHNTConversionAlert()
+        const success = await showHNTConversionAlert()
+        if (!success) {
+          setRedeeming(false)
+          return
+        }
       }
 
       const balanceChanges: BalanceChange[] = []


### PR DESCRIPTION
Claim all transaction and screen was still being attempted even if user didn't have enough sol if they chose not to convert to SOL from HNT