### PR TITLE
Add verify to handleEdit address

### DIFF
--- a/src/features/payment/PaymentItem.tsx
+++ b/src/features/payment/PaymentItem.tsx
@@ -123,7 +123,7 @@ const PaymentItem = ({
   }, [debouncedAddress, handleEditAddress])
 
   useEffect(() => {
-    if (rawAddress.split('.').length !== 2) {
+    if (rawAddress && rawAddress.split('.').length !== 2) {
       handleEditAddress(rawAddress)
     }
   }, [rawAddress, handleEditAddress])


### PR DESCRIPTION
Bulk payout using the deep link, the first recipient is empty

Closes #559 

BUG:
https://github.com/helium/wallet-app/assets/37663993/2bb74819-79fc-46da-940b-041da658997c

DEMO:
https://github.com/helium/wallet-app/assets/37663993/05e504ac-3408-46dc-b7cf-dd0cb5856259

