### PR TITLE
Remove Crowdspot reference

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -642,7 +642,7 @@ export default {
     timeoutAlert: {
       title: 'Login Failed',
       message:
-        'Please close and reopen the login screen in Crowdspot and scan a new QR code to try again.',
+        'Please close and reopen the login screen and scan a new QR code to try again.',
     },
   },
   editContact: {


### PR DESCRIPTION
Changing failed login message to be more generic instead of referring to Crowdspot.