### PR TITLE
feat(#738): Annotate transactions that were signed vs unsigned to help prevent address poisoning

### DIFF
--- a/src/features/activity/ActivityListItem.tsx
+++ b/src/features/activity/ActivityListItem.tsx
@@ -1,14 +1,16 @@
-import React, { useMemo } from 'react'
-import { ConfirmedSignatureInfo } from '@solana/web3.js'
-import { useTranslation } from 'react-i18next'
-import CheckmarkFilled from '@assets/images/checkmarkFill.svg'
+import Send from '@assets/images/send.svg'
+import Receive from '@assets/images/receive.svg'
 import Error from '@assets/images/error.svg'
-import Text from '@components/Text'
 import Box from '@components/Box'
-import { TouchableOpacityBoxProps } from '@components/TouchableOpacityBox'
-import { useColors } from '@theme/themeHooks'
+import Text from '@components/Text'
 import TouchableContainer from '@components/TouchableContainer'
+import { TouchableOpacityBoxProps } from '@components/TouchableOpacityBox'
+import { useCurrentWallet } from '@hooks/useCurrentWallet'
+import { ConfirmedSignatureInfo } from '@solana/web3.js'
+import { useColors } from '@theme/themeHooks'
 import { ellipsizeAddress, solAddressIsValid } from '@utils/accountUtils'
+import React, { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Insets } from 'react-native'
 import { EnrichedTransaction } from '../../types/solana'
 
@@ -25,6 +27,8 @@ const ActivityListItem = ({
 }: ActivityListItemProps) => {
   const colors = useColors()
   const { t, i18n } = useTranslation()
+
+  const wallet = useCurrentWallet()
 
   const title = useMemo(() => {
     const enrichedTx = transaction as EnrichedTransaction
@@ -80,17 +84,31 @@ const ActivityListItem = ({
     return !!confirmedSig?.err || !!enrichedTx.transactionError
   }, [transaction])
 
+  const userSignedTransaction = useMemo(() => {
+    const enrichedTx = transaction as EnrichedTransaction
+    if (wallet && enrichedTx.signers) {
+      return enrichedTx.signers?.includes(wallet?.toBase58())
+    }
+
+    return false
+  }, [transaction, wallet])
+
   return (
     <TouchableContainer
       backgroundColor="surfaceSecondary"
       flexDirection="row"
+      alignItems="center"
       padding="m"
       borderBottomWidth={hasDivider ? 1 : 0}
       borderBottomColor="black"
       {...rest}
     >
       {!transactionFailed ? (
-        <CheckmarkFilled width={25} height={25} color={colors.greenBright500} />
+        userSignedTransaction ? (
+          <Send width={25} height={25} color={colors.green500} />
+        ) : (
+          <Receive width={25} height={25} color={colors.blue500} />
+        )
       ) : (
         <Error width={25} height={25} color={colors.error} />
       )}

--- a/src/types/solana.ts
+++ b/src/types/solana.ts
@@ -137,6 +137,7 @@ type NativeTokenPayload = {
 }
 
 export type EnrichedTransaction = {
+  signers: string[]
   description: string
   type: string
   source: string


### PR DESCRIPTION
![simulator_screenshot_A999B3D8-BF10-4E82-A235-89847A2BB4A2](https://github.com/helium/wallet-app/assets/83885631/e01ff68d-f599-4c69-8803-3c7925c23e6b)


You can see here the arrows pointing out mean I signed. App Interaction are some governance claims.

The transactions afterword were 1 lamport transferred to me by address poisoning low lifes