### PR TITLE
Show jupiter error before tx error

### DIFF
--- a/src/features/swaps/SwapScreen.tsx
+++ b/src/features/swaps/SwapScreen.tsx
@@ -178,8 +178,8 @@ const SwapScreen = () => {
       return t('swapsScreen.insufficientTokensToSwap')
     if (hasInsufficientBalance) return t('generic.insufficientBalance')
     if (networkError) return networkError
-    if (transactionError) return transactionError
     if (jupiterError) return jupiterError
+    if (transactionError) return transactionError
     if (routeNotFound) return t('swapsScreen.routeNotFound')
   }, [
     hasRecipientError,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/523753eb-5111-4d27-aad4-dad06c0281c5)

Community members reporting this issue, it's indicative of a Jupiter error but we can't see the Jupiter error because it's lower in priority