### PR TITLE
remove unused react-native-vision-camera

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1549,12 +1549,6 @@ PODS:
     - React
   - Toast (4.0.0)
   - Turf (3.0.0)
-  - VisionCamera (4.5.3):
-    - VisionCamera/Core (= 4.5.3)
-    - VisionCamera/React (= 4.5.3)
-  - VisionCamera/Core (4.5.3)
-  - VisionCamera/React (4.5.3):
-    - React-Core
   - Yoga (0.0.0)
   - ZXingObjC/Core (3.6.9)
   - ZXingObjC/OneD (3.6.9):
@@ -1678,7 +1672,6 @@ DEPENDENCIES:
   - RNSVG (from `../node_modules/react-native-svg`)
   - RNTestFlight (from `../node_modules/react-native-test-flight`)
   - TcpSockets (from `../node_modules/react-native-tcp`)
-  - VisionCamera (from `../node_modules/react-native-vision-camera`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -1922,8 +1915,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-test-flight"
   TcpSockets:
     :path: "../node_modules/react-native-tcp"
-  VisionCamera:
-    :path: "../node_modules/react-native-vision-camera"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -2052,10 +2043,9 @@ SPEC CHECKSUMS:
   TcpSockets: 14306fb79f9750ea7d2ddd02d8bed182abb01797
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
   Turf: a1604e74adce15c58462c9ae2acdbf049d5be35e
-  VisionCamera: cb84d0d8485b3e67c91b62931d3aa88f49747c92
-  Yoga: 950bbfd7e6f04790fdb51149ed51df41f329fcc8
+  Yoga: 2246eea72aaf1b816a68a35e6e4b74563653ae09
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 51a354c5ff94b58e8c8bd1903d2326a93a17b4d0
 
-COCOAPODS: 1.16.1
+COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -216,7 +216,6 @@
     "react-native-udp": "2.7.0",
     "react-native-url-polyfill": "2.0.0",
     "react-native-video": "5.2.1",
-    "react-native-vision-camera": "4.5.3",
     "react-native-webview": "13.10.5",
     "react-redux": "8.0.4",
     "readable-stream": "3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15868,7 +15868,6 @@ __metadata:
     react-native-udp: 2.7.0
     react-native-url-polyfill: 2.0.0
     react-native-video: 5.2.1
-    react-native-vision-camera: 4.5.3
     react-native-webview: 13.10.5
     react-redux: 8.0.4
     react-test-renderer: 17.0.2
@@ -22297,26 +22296,6 @@ __metadata:
     prop-types: ^15.7.2
     shaka-player: ^2.5.9
   checksum: efbc09a47e3080dde2986a3a1ea3f32b815317f99013c015522fd2e6ed937ed02244761f4dd5c8f5bf0260bf8a1d518315025cae499c16a6c3b1cd0fa6935d2d
-  languageName: node
-  linkType: hard
-
-"react-native-vision-camera@npm:4.5.3":
-  version: 4.5.3
-  resolution: "react-native-vision-camera@npm:4.5.3"
-  peerDependencies:
-    "@shopify/react-native-skia": "*"
-    react: "*"
-    react-native: "*"
-    react-native-reanimated: "*"
-    react-native-worklets-core: "*"
-  peerDependenciesMeta:
-    "@shopify/react-native-skia":
-      optional: true
-    react-native-reanimated:
-      optional: true
-    react-native-worklets-core:
-      optional: true
-  checksum: 99d57a70f93134903ae25ef798947f79804ea00e3b58cbb21131115552e6f2950d2a3be9a6a237232ca6bab7b5031aa12d9ca2df659be39dc607d75997317abc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Removed it in another PR to use expo-camera but bad merge brought back the dependency. Removing it again.