### PR TITLE
relabel delegationSplit

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1376,7 +1376,7 @@ export default {
       enableAutomation: 'Enable automatic claiming of rewards',
       rentFees: 'Reclaimable SOL',
       prepaidTxFees: 'Prepaid Transaction Fees',
-      delegationSplit: 'HNT Emissions Split from Delegations',
+      delegationSplit: 'Current Delegation Split',
       dataUsageRevenue: 'Data Usage Revenue (30 days)',
     },
     positions: {


### PR DESCRIPTION
The number displayed in the app is the percentage of veHNT delegated to each network, not the current split of HNT emissions. That’s determined by the smoothed Protocol Score as defined in HIP-141, not the raw delegation split.