### PR TITLE
Fix iOS warning

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -11,7 +11,11 @@
     "preview": {
       "distribution": "internal"
     },
-    "production": {}
+    "production": {
+      "ios": {
+        "image": "macos-sequoia-15.6-xcode-26.2"
+      }
+    }
   },
   "submit": {
     "production": {


### PR DESCRIPTION
Hello,

We noticed one or more issues with a recent delivery for the following app:

Helium Wallet
App Apple ID xxxx
Version 2.15.4
Build 1776718935
Although delivery was successful, you may want to correct the following issues in your next delivery. Once you've corrected the issues, upload a new binary to App Store Connect.

ITMS-90725: SDK version issue - This app was built with the iOS 18.5 SDK. Starting April 28, 2026, all iOS and iPadOS apps must be built with the iOS 26 SDK or later, included in Xcode 26 or later, in order to be uploaded to App Store Connect or submitted for distribution.

Apple Developer Relations