### PR TITLE
fix: pass serialized txs to sign sheet for signAndSendTransaction

### DIFF
--- a/src/features/browser/BrowserWebViewScreen.tsx
+++ b/src/features/browser/BrowserWebViewScreen.tsx
@@ -218,10 +218,17 @@ const BrowserWebViewScreen = () => {
     async (inputs: SolanaSignAndSendTransactionInput[]) => {
       Logger.breadcrumb('signAndSendTransaction')
 
+      const txBuffers: Buffer[] = inputs.map(({ transaction }) =>
+        Buffer.from(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          Object.keys(transaction).map((k) => (transaction as any)[k]),
+        ),
+      )
+
       const decision = await walletSignBottomSheetRef.current?.show({
         type: WalletStandardMessageTypes.signAndSendTransaction,
         url: currentUrl,
-        serializedTxs: undefined,
+        serializedTxs: txBuffers,
       })
 
       if (!decision) {


### PR DESCRIPTION
handleSignAndSendTransaction showed the approval sheet with serializedTxs: undefined, so the simulated sheet never ran sus() — no balance-change preview, no blacklist warnings, and a ~0 SOL fee estimate for the default dApp signing path. Build the tx buffers from the inputs (same as handleSignTransaction) and pass them.