### PR TITLE
Migrate all visible tokens to World

### DIFF
--- a/src/features/account/AccountManageTokenListScreen.tsx
+++ b/src/features/account/AccountManageTokenListScreen.tsx
@@ -29,7 +29,7 @@ import { syncTokenAccounts } from '../../store/slices/balancesSlice'
 import { useAppDispatch } from '../../store/store'
 import { HomeNavigationProp } from '../home/homeTypes'
 import AccountTokenCurrencyBalance from './AccountTokenCurrencyBalance'
-import { getSortValue } from './AccountTokenList'
+import { getSortValue } from './logic/visibleTokens'
 
 const CheckableTokenListItem = ({
   bottomBorder,

--- a/src/features/account/AccountTokenList.tsx
+++ b/src/features/account/AccountTokenList.tsx
@@ -3,12 +3,10 @@ import Text from '@components/Text'
 import TouchableOpacityBox from '@components/TouchableOpacityBox'
 import { BottomSheetFlatList } from '@gorhom/bottom-sheet'
 import { BottomSheetFlatListProps } from '@gorhom/bottom-sheet/lib/typescript/components/bottomSheetScrollable/types'
-import { DC_MINT, HNT_MINT, IOT_MINT, MOBILE_MINT } from '@helium/spl-utils'
-import { NATIVE_MINT } from '@solana/spl-token'
 import { useNavigation } from '@react-navigation/native'
 import { PublicKey } from '@solana/web3.js'
 import { useAccountStorage } from '@storage/AccountStorageProvider'
-import { DEFAULT_TOKENS, useVisibleTokens } from '@storage/TokensProvider'
+import { useVisibleTokens } from '@storage/TokensProvider'
 import { useColors } from '@theme/themeHooks'
 import { useBalance } from '@utils/Balance'
 import { times } from 'lodash'
@@ -23,22 +21,11 @@ import { useSolana } from '../../solana/SolanaProvider'
 import { syncTokenAccounts } from '../../store/slices/balancesSlice'
 import { useAppDispatch } from '../../store/store'
 import { HomeNavigationProp } from '../home/homeTypes'
+import { deriveVisibleMints } from './logic/visibleTokens'
 import { TokenListItem, TokenListGovItem, TokenSkeleton } from './TokenListItem'
-
-const USDC_MINT = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
 
 type Props = {
   onLayout?: BottomSheetFlatListProps<PublicKey>['onLayout']
-}
-
-const sortValues: Record<string, number> = {
-  [HNT_MINT.toBase58()]: 10,
-  [IOT_MINT.toBase58()]: 9,
-  [MOBILE_MINT.toBase58()]: 8,
-  [DC_MINT.toBase58()]: 7,
-}
-export function getSortValue(mint: string): number {
-  return sortValues[mint] || 0
 }
 
 const AccountTokenList = ({ onLayout }: Props) => {
@@ -86,40 +73,13 @@ const AccountTokenList = ({ onLayout }: Props) => {
   }, [navigation])
   const { tokenAccounts } = useBalance()
   const { bottom } = useSafeAreaInsets()
-  const mints = useMemo(() => {
-    const taMints = tokenAccounts
-      ?.filter(
-        (ta) =>
-          visibleTokens.has(ta.mint) &&
-          ta.balance > 0 &&
-          (ta.decimals > 0 || ta.mint === DC_MINT.toBase58()),
-      )
-      .map((ta) => ta.mint)
-
-    // Start with DEFAULT_TOKENS, then filter out any that have zero balance
-    // (unless they're not in tokenAccounts at all, meaning no account exists)
-    const all = [...new Set([...DEFAULT_TOKENS, ...(taMints || [])])]
-      .filter((mintStr) => {
-        // If token has an account, only show if balance > 0
-        const tokenAccount = tokenAccounts?.find((ta) => ta.mint === mintStr)
-        if (tokenAccount) {
-          return (
-            tokenAccount.balance > 0 ||
-            tokenAccount.mint === DC_MINT.toBase58() ||
-            tokenAccount.mint === NATIVE_MINT.toBase58() ||
-            tokenAccount.mint === USDC_MINT.toBase58()
-          )
-        }
-        // If no token account exists, show the default token (user can add it later)
-        return true
-      })
-      .sort((a, b) => {
-        return getSortValue(b) - getSortValue(a)
-      })
-      .map((mint) => new PublicKey(mint))
-
-    return all
-  }, [tokenAccounts, visibleTokens])
+  const mints = useMemo(
+    () =>
+      deriveVisibleMints({ tokenAccounts, visibleTokens }).map(
+        (mint) => new PublicKey(mint),
+      ),
+    [tokenAccounts, visibleTokens],
+  )
 
   const bottomSpace = useMemo(() => bottom * 2, [bottom])
 

--- a/src/features/account/logic/__tests__/visibleTokens.test.ts
+++ b/src/features/account/logic/__tests__/visibleTokens.test.ts
@@ -1,0 +1,103 @@
+import { deriveVisibleMints } from '../visibleTokens'
+
+const HNT = 'hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux'
+const MOBILE = 'mb1eu7TzEc71KxDpsmsKoucSSuuoGLv1drys1oP2jh6'
+const IOT = 'iotEVVZLEywoTn1QdwNPddxPWszn3zFhEot3MfL9fns'
+const DC = 'dcuc8Amr83Wz27ZkQ2K9NS6r8zRpf1J6cvArEBDZDmm'
+const SOL = 'So11111111111111111111111111111111111111112'
+const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+const BONK = 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263'
+const WIF = 'EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm'
+const NFT = 'NFTmint11111111111111111111111111111111111'
+
+describe('deriveVisibleMints', () => {
+  it('always includes the default tokens, even with no token accounts', () => {
+    const mints = deriveVisibleMints({
+      tokenAccounts: undefined,
+      visibleTokens: new Set<string>(),
+    })
+
+    expect(new Set(mints)).toEqual(new Set([HNT, MOBILE, IOT, DC, SOL, USDC]))
+  })
+
+  it('includes a visible non-default token with a balance', () => {
+    const mints = deriveVisibleMints({
+      tokenAccounts: [{ mint: BONK, balance: 1000, decimals: 5 }],
+      visibleTokens: new Set([BONK]),
+    })
+
+    expect(mints).toContain(BONK)
+  })
+
+  it('excludes a hidden token even when it has a balance', () => {
+    const mints = deriveVisibleMints({
+      tokenAccounts: [
+        { mint: BONK, balance: 1000, decimals: 5 },
+        { mint: WIF, balance: 2000, decimals: 6 },
+      ],
+      visibleTokens: new Set([BONK]),
+    })
+
+    expect(mints).not.toContain(WIF)
+  })
+
+  it('drops a default token whose account is empty', () => {
+    const mints = deriveVisibleMints({
+      tokenAccounts: [{ mint: HNT, balance: 0, decimals: 8 }],
+      visibleTokens: new Set([HNT]),
+    })
+
+    expect(mints).not.toContain(HNT)
+  })
+
+  it('keeps DC, SOL and USDC when their accounts are empty', () => {
+    const mints = deriveVisibleMints({
+      tokenAccounts: [
+        { mint: DC, balance: 0, decimals: 0 },
+        { mint: SOL, balance: 0, decimals: 9 },
+        { mint: USDC, balance: 0, decimals: 6 },
+      ],
+      visibleTokens: new Set([DC, SOL, USDC]),
+    })
+
+    expect(mints).toEqual(expect.arrayContaining([DC, SOL, USDC]))
+  })
+
+  it('excludes NFT-like accounts, which have no decimals', () => {
+    const mints = deriveVisibleMints({
+      tokenAccounts: [{ mint: NFT, balance: 1, decimals: 0 }],
+      visibleTokens: new Set([NFT]),
+    })
+
+    expect(mints).not.toContain(NFT)
+  })
+
+  it('keeps DC despite its zero decimals', () => {
+    const mints = deriveVisibleMints({
+      tokenAccounts: [{ mint: DC, balance: 5000, decimals: 0 }],
+      visibleTokens: new Set([DC]),
+    })
+
+    expect(mints).toContain(DC)
+  })
+
+  // Captured from the account token list before the derivation moved here, so a
+  // change in either membership or order fails.
+  it('reproduces the account token list for a whole account', () => {
+    const mints = deriveVisibleMints({
+      tokenAccounts: [
+        { mint: USDC, balance: 0, decimals: 6 },
+        { mint: BONK, balance: 1000, decimals: 5 },
+        { mint: WIF, balance: 2000, decimals: 6 },
+        { mint: NFT, balance: 1, decimals: 0 },
+        { mint: HNT, balance: 500, decimals: 8 },
+        { mint: SOL, balance: 12345, decimals: 9 },
+        { mint: DC, balance: 0, decimals: 0 },
+        { mint: MOBILE, balance: 750, decimals: 6 },
+      ],
+      visibleTokens: new Set([HNT, MOBILE, IOT, DC, SOL, USDC, BONK, NFT]),
+    })
+
+    expect(mints).toEqual([HNT, IOT, MOBILE, DC, SOL, USDC, BONK])
+  })
+})

--- a/src/features/account/logic/visibleTokens.ts
+++ b/src/features/account/logic/visibleTokens.ts
@@ -39,6 +39,12 @@ export type VisibleTokenAccount = {
   decimals: number
 }
 
+// Decimals-less accounts are NFTs, which the token list never shows. DC is the
+// one fungible exception. Migration shares this so both flows agree on what
+// counts as a token.
+export const isNftLike = (ta: Pick<VisibleTokenAccount, 'mint' | 'decimals'>) =>
+  ta.decimals === 0 && ta.mint !== DC
+
 export const deriveVisibleMints = (args: {
   tokenAccounts: VisibleTokenAccount[] | undefined
   visibleTokens: ReadonlySet<string>
@@ -47,11 +53,7 @@ export const deriveVisibleMints = (args: {
 
   const taMints = tokenAccounts
     ?.filter(
-      (ta) =>
-        visibleTokens.has(ta.mint) &&
-        ta.balance > 0 &&
-        // Decimals-less accounts are NFTs, which the token list never shows.
-        (ta.decimals > 0 || ta.mint === DC),
+      (ta) => visibleTokens.has(ta.mint) && ta.balance > 0 && !isNftLike(ta),
     )
     .map((ta) => ta.mint)
 

--- a/src/features/account/logic/visibleTokens.ts
+++ b/src/features/account/logic/visibleTokens.ts
@@ -1,0 +1,68 @@
+import { DC_MINT, HNT_MINT, IOT_MINT, MOBILE_MINT } from '@helium/spl-utils'
+import { NATIVE_MINT } from '@solana/spl-token'
+
+// Pure derivation of the account token list. Kept free of React Native imports
+// so it runs under node-jest and can be reused by the migration flow.
+
+const DC = DC_MINT.toBase58()
+const SOL = NATIVE_MINT.toBase58()
+const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+
+// Mints every account shows, whether or not the wallet holds them.
+export const DEFAULT_TOKENS = new Set([
+  HNT_MINT.toBase58(),
+  MOBILE_MINT.toBase58(),
+  IOT_MINT.toBase58(),
+  DC,
+  SOL,
+  USDC,
+])
+
+// Listed even at zero: DC and SOL fund everything else, USDC is the on-ramp.
+const BALANCE_EXEMPT_MINTS = new Set([DC, SOL, USDC])
+
+// Network tokens lead the list, highest first; everything else keeps the order
+// it arrived in.
+const sortValues: Record<string, number> = {
+  [HNT_MINT.toBase58()]: 10,
+  [IOT_MINT.toBase58()]: 9,
+  [MOBILE_MINT.toBase58()]: 8,
+  [DC]: 7,
+}
+
+export const getSortValue = (mint: string): number => sortValues[mint] || 0
+
+// A wallet ATA, from useBalance().tokenAccounts. balance is the raw amount.
+export type VisibleTokenAccount = {
+  mint: string
+  balance: number
+  decimals: number
+}
+
+export const deriveVisibleMints = (args: {
+  tokenAccounts: VisibleTokenAccount[] | undefined
+  visibleTokens: ReadonlySet<string>
+}): string[] => {
+  const { tokenAccounts, visibleTokens } = args
+
+  const taMints = tokenAccounts
+    ?.filter(
+      (ta) =>
+        visibleTokens.has(ta.mint) &&
+        ta.balance > 0 &&
+        // Decimals-less accounts are NFTs, which the token list never shows.
+        (ta.decimals > 0 || ta.mint === DC),
+    )
+    .map((ta) => ta.mint)
+
+  return [...new Set([...DEFAULT_TOKENS, ...(taMints || [])])]
+    .filter((mint) => {
+      // A default token with no account at all stays listed so the user can
+      // fund it later; once an account exists it has to hold something.
+      const tokenAccount = tokenAccounts?.find((ta) => ta.mint === mint)
+      if (!tokenAccount) return true
+
+      return tokenAccount.balance > 0 || BALANCE_EXEMPT_MINTS.has(mint)
+    })
+    .sort((a, b) => getSortValue(b) - getSortValue(a))
+}

--- a/src/features/migration/components/AssetSelectionStep.tsx
+++ b/src/features/migration/components/AssetSelectionStep.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { RootState } from '../../../store/rootReducer'
 import { MigratableHotspot } from '../hooks/useMigrationAssets'
-import { MINT_PRICE_KEY } from '../logic/mints'
+import { estimateFiat } from '../logic/fiat'
 import { SelectableToken } from '../logic/types'
 import { WORLD_TRACKING } from '../migrationTheme'
 import HotspotsEditSheet from './HotspotsEditSheet'
@@ -137,28 +137,26 @@ const AssetSelectionStep: FC<{
     return a && a !== '0'
   }).length
 
-  // Approximate USD value of the selected token amounts, summed over the mints
-  // we have a price for. Omitted entirely when no price is available.
+  // Approximate value of the selected token amounts over the mints we have a
+  // price for, plus how many selected tokens we cannot price. Omitted entirely
+  // until prices load, and when nothing is selected.
   const cur = currency?.toLowerCase()
   const tokensUsd = useMemo(() => {
     if (!cur || !tokenPrices) return undefined
-    let total = 0
-    let priced = false
-    tokens.forEach((tk) => {
-      const key = MINT_PRICE_KEY[tk.mint]
-      const price = key
-        ? tokenPrices[key as keyof typeof tokenPrices]?.[cur]
-        : undefined
-      const amt = parseFloat(tokenAmounts[tk.mint] ?? '')
-      if (price && amt > 0) {
-        total += price * amt
-        priced = true
-      }
+    const { total, unpricedCount } = estimateFiat({
+      tokens,
+      amounts: tokenAmounts,
+      prices: tokenPrices,
+      currency: cur,
     })
-    if (!priced) return undefined
-    return t('migrateToWorld.selectAssets.approxValue', {
-      value: numberFormat(language, cur, total),
-    })
+    if (!total && !unpricedCount) return undefined
+    const value = numberFormat(language, cur, total)
+    return unpricedCount
+      ? t('migrateToWorld.selectAssets.approxValueUnpriced', {
+          value,
+          unpriced: unpricedCount,
+        })
+      : t('migrateToWorld.selectAssets.approxValue', { value })
   }, [tokens, tokenAmounts, tokenPrices, cur, language, t])
 
   const canReview = hotspotKeys.size > 0 || activeTokenCount > 0

--- a/src/features/migration/components/AssetSelectionStep.tsx
+++ b/src/features/migration/components/AssetSelectionStep.tsx
@@ -110,8 +110,10 @@ const AssetSelectionStep: FC<{
 
   // Pre-select everything the first time assets arrive. Adjusting state
   // during render (guarded so it runs once) is the idiomatic React pattern
-  // for deriving state from new props without an extra effect pass.
-  if (!primed && (hotspots.length || tokens.length)) {
+  // for deriving state from new props without an extra effect pass. Tokens are
+  // local and land before the hotspot fetch settles, so wait for the load to
+  // finish or the hotspots would prime as none-selected.
+  if (!primed && !loading && (hotspots.length || tokens.length)) {
     setHotspotKeys(new Set(hotspots.map((h) => h.entityKey)))
     setTokenAmounts(Object.fromEntries(tokens.map((tk) => [tk.mint, tk.maxUi])))
     setPrimed(true)
@@ -207,7 +209,8 @@ const AssetSelectionStep: FC<{
             <Text variant="body3" color="worldWarnInk">
               {t('migrateToWorld.selectAssets.leftBehind', {
                 count: leftBehindCount,
-              })}
+              })}{' '}
+              {t('migrateToWorld.selectAssets.leftBehindHint')}
             </Text>
           </Box>
         )}

--- a/src/features/migration/components/AssetSelectionStep.tsx
+++ b/src/features/migration/components/AssetSelectionStep.tsx
@@ -110,9 +110,9 @@ const AssetSelectionStep: FC<{
 
   // Pre-select everything the first time assets arrive. Adjusting state
   // during render (guarded so it runs once) is the idiomatic React pattern
-  // for deriving state from new props without an extra effect pass. Tokens are
-  // local and land before the hotspot fetch settles, so wait for the load to
-  // finish or the hotspots would prime as none-selected.
+  // for deriving state from new props without an extra effect pass. `loading`
+  // covers hotspots, token accounts and SOL, so nothing arrives after the prime
+  // and lands unselected.
   if (!primed && !loading && (hotspots.length || tokens.length)) {
     setHotspotKeys(new Set(hotspots.map((h) => h.entityKey)))
     setTokenAmounts(Object.fromEntries(tokens.map((tk) => [tk.mint, tk.maxUi])))

--- a/src/features/migration/components/ReviewStep.tsx
+++ b/src/features/migration/components/ReviewStep.tsx
@@ -6,6 +6,7 @@ import { shortenAddress } from '@utils/formatting'
 import React, { FC, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView } from 'react-native'
+import { useTokenDisplay } from '../hooks/useTokenDisplay'
 import { WORLD_TRACKING } from '../migrationTheme'
 import StepBackHeader from './StepBackHeader'
 import WorldButton from './WorldButton'
@@ -45,6 +46,18 @@ const Line: FC<{ label: string; value: string }> = ({ label, value }) => (
 )
 
 const Divider = () => <Box height={1} backgroundColor="worldBorder" />
+
+// Its own component so each line can resolve its token metadata; the label the
+// classifier supplied is the fallback for a token with no metadata.
+const TokenLine: FC<{ line: ReviewTokenLine }> = ({ line }) => {
+  const { label } = useTokenDisplay(line.mint, line.label)
+  return (
+    <Box>
+      <Divider />
+      <Line label={label} value={line.amount} />
+    </Box>
+  )
+}
 
 // A hairline divider with a centered down-arrow badge, showing assets flowing
 // from the source wallet into the destination. The container is tall enough to
@@ -122,10 +135,7 @@ const ReviewStep: FC<{
               value={String(hotspotCount)}
             />
             {tokenLines.map((line) => (
-              <Box key={line.mint}>
-                <Divider />
-                <Line label={line.label} value={line.amount} />
-              </Box>
+              <TokenLine key={line.mint} line={line} />
             ))}
           </Card>
 

--- a/src/features/migration/components/TokensEditSheet.tsx
+++ b/src/features/migration/components/TokensEditSheet.tsx
@@ -7,11 +7,10 @@ import BottomSheet, {
   BottomSheetBackdropProps,
   BottomSheetScrollView,
 } from '@gorhom/bottom-sheet'
-import { useMetaplexMetadata } from '@hooks/useMetaplexMetadata'
-import { PublicKey } from '@solana/web3.js'
-import React, { FC, forwardRef, useCallback, useMemo, useState } from 'react'
+import React, { FC, forwardRef, useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TextInput } from 'react-native'
+import { useTokenDisplay } from '../hooks/useTokenDisplay'
 import { WSOL_MINT } from '../logic/mints'
 import { SelectableToken } from '../logic/types'
 import {
@@ -39,8 +38,7 @@ const TokenRow: FC<{
   onMax: () => void
 }> = ({ token, value, onChange, onMax }) => {
   const { t } = useTranslation()
-  const mint = useMemo(() => new PublicKey(token.mint), [token.mint])
-  const { json } = useMetaplexMetadata(mint)
+  const { label, image } = useTokenDisplay(token.mint, token.label)
   const isSol = token.mint === WSOL_MINT
 
   if (!isSol) {
@@ -56,10 +54,10 @@ const TokenRow: FC<{
         <Box marginRight="m">
           <WorldCheckbox checked={isSelected} />
         </Box>
-        <TokenIcon size={32} img={json?.image} />
+        <TokenIcon size={32} img={image} />
         <Box flex={1} marginLeft="s">
           <Text variant="body2Medium" color="worldInk">
-            {token.label}
+            {label}
           </Text>
           <Text variant="body3" color="worldSecondaryInk" marginTop="xxs">
             {t('migrateToWorld.selectAssets.balance', {
@@ -81,10 +79,10 @@ const TokenRow: FC<{
       {/* Spacer matching the checkbox column so the SOL row's icon/label
           stay aligned with the toggle rows above. */}
       <Box width={22} marginRight="m" />
-      <TokenIcon size={32} img={json?.image} />
+      <TokenIcon size={32} img={image} />
       <Box flex={1} marginLeft="s">
         <Text variant="body2Medium" color="worldInk">
-          {token.label}
+          {label}
         </Text>
         <TouchableOpacityBox
           onPress={onMax}

--- a/src/features/migration/hooks/useMigrationAssets.ts
+++ b/src/features/migration/hooks/useMigrationAssets.ts
@@ -6,6 +6,8 @@ import { usePublicKey } from '@hooks/usePublicKey'
 import { useBalance } from '@utils/Balance'
 import { useEffect, useMemo } from 'react'
 import { useAsyncCallback } from 'react-async-hook'
+import { useSelector } from 'react-redux'
+import { RootState } from '../../../store/rootReducer'
 import { classifyHoldings } from '../logic/assets'
 
 export type MigratableHotspot = {
@@ -23,7 +25,12 @@ export const useMigrationAssets = (sourceWallet: string | undefined) => {
   const client = useBlockchainApi()
   const { tokenAccounts } = useBalance()
   const { visibleTokens } = useVisibleTokens()
-  const { amount: lamports } = useSolOwnedAmount(usePublicKey(sourceWallet))
+  const balancesLoading = useSelector(
+    (s: RootState) => s.balances.balancesLoading,
+  )
+  const { amount: lamports, loading: solLoading } = useSolOwnedAmount(
+    usePublicKey(sourceWallet),
+  )
 
   const { execute, loading, result, error } = useAsyncCallback(async () => {
     if (!sourceWallet) return [] as MigratableHotspot[]
@@ -53,8 +60,15 @@ export const useMigrationAssets = (sourceWallet: string | undefined) => {
   return {
     // The kick-off effect fires after the first render with a wallet, so count
     // that not-yet-started gap as loading — an empty pre-fetch snapshot must
-    // not read as a wallet with nothing to migrate.
-    loading: loading || (!!sourceWallet && !result && !error),
+    // not read as a wallet with nothing to migrate. Tokens and SOL come from
+    // their own async sources; the selection step primes once, so all three
+    // must settle before loading clears or late rows arrive unselected.
+    loading:
+      loading ||
+      (!!sourceWallet && !result && !error) ||
+      !!balancesLoading ||
+      solLoading ||
+      tokenAccounts === undefined,
     error,
     reload: execute,
     hotspots: result ?? NO_HOTSPOTS,

--- a/src/features/migration/hooks/useMigrationAssets.ts
+++ b/src/features/migration/hooks/useMigrationAssets.ts
@@ -1,5 +1,4 @@
 import { useSolOwnedAmount } from '@helium/helium-react-hooks'
-import { LAMPORTS_PER_SOL } from '@solana/web3.js'
 import { useBlockchainApi } from '@storage/BlockchainApiProvider'
 import { useVisibleTokens } from '@storage/TokensProvider'
 import { usePublicKey } from '@hooks/usePublicKey'
@@ -52,7 +51,7 @@ export const useMigrationAssets = (sourceWallet: string | undefined) => {
       classifyHoldings({
         holdings: tokenAccounts ?? [],
         visibleTokens,
-        solBalance: Number(lamports ?? 0) / LAMPORTS_PER_SOL,
+        solLamports: lamports ?? 0,
       }),
     [tokenAccounts, visibleTokens, lamports],
   )

--- a/src/features/migration/hooks/useMigrationAssets.ts
+++ b/src/features/migration/hooks/useMigrationAssets.ts
@@ -1,9 +1,12 @@
+import { useSolOwnedAmount } from '@helium/helium-react-hooks'
+import { LAMPORTS_PER_SOL } from '@solana/web3.js'
 import { useBlockchainApi } from '@storage/BlockchainApiProvider'
+import { useVisibleTokens } from '@storage/TokensProvider'
+import { usePublicKey } from '@hooks/usePublicKey'
 import { useBalance } from '@utils/Balance'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useAsyncCallback } from 'react-async-hook'
 import { classifyHoldings } from '../logic/assets'
-import { SelectableToken } from '../logic/types'
 
 export type MigratableHotspot = {
   entityKey: string
@@ -12,50 +15,40 @@ export type MigratableHotspot = {
   deviceType: string
 }
 
-// Stable fallbacks so consumers' memos aren't invalidated by fresh [] identities
-// on every render while the assets are still loading.
+// Stable fallback so consumers' memos aren't invalidated by a fresh []
+// identity on every render while the hotspots are still loading.
 const NO_HOTSPOTS: MigratableHotspot[] = []
-const NO_TOKENS: SelectableToken[] = []
-const NO_MINTS: string[] = []
 
 export const useMigrationAssets = (sourceWallet: string | undefined) => {
   const client = useBlockchainApi()
   const { tokenAccounts } = useBalance()
+  const { visibleTokens } = useVisibleTokens()
+  const { amount: lamports } = useSolOwnedAmount(usePublicKey(sourceWallet))
 
   const { execute, loading, result, error } = useAsyncCallback(async () => {
-    if (!sourceWallet) {
-      return {
-        hotspots: [] as MigratableHotspot[],
-        tokens: [] as SelectableToken[],
-        leftBehindMints: [] as string[],
-      }
-    }
-    const [hotspotsResult, balances] = await Promise.all([
-      client.migration.getHotspots({ walletAddress: sourceWallet }),
-      client.tokens.getBalances({ walletAddress: sourceWallet }),
-    ])
-
-    const { migratableTokens, leftBehindMints } = classifyHoldings({
-      migratable: balances.tokens,
-      solBalance: balances.solBalance,
-      holdings: (tokenAccounts ?? []).map((a) => ({
-        mint: a.mint,
-        balance: a.balance,
-        decimals: a.decimals,
-      })),
+    if (!sourceWallet) return [] as MigratableHotspot[]
+    const { hotspots } = await client.migration.getHotspots({
+      walletAddress: sourceWallet,
     })
-
-    return {
-      hotspots: hotspotsResult.hotspots as MigratableHotspot[],
-      tokens: migratableTokens,
-      leftBehindMints,
-    }
+    return hotspots as MigratableHotspot[]
   })
 
   useEffect(() => {
     if (sourceWallet) execute()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sourceWallet])
+
+  // The migratable set is the wallet's own view of what it holds — no token
+  // list from the server, so one fewer call that can fail.
+  const { migratableTokens, leftBehindMints } = useMemo(
+    () =>
+      classifyHoldings({
+        holdings: tokenAccounts ?? [],
+        visibleTokens,
+        solBalance: Number(lamports ?? 0) / LAMPORTS_PER_SOL,
+      }),
+    [tokenAccounts, visibleTokens, lamports],
+  )
 
   return {
     // The kick-off effect fires after the first render with a wallet, so count
@@ -64,8 +57,8 @@ export const useMigrationAssets = (sourceWallet: string | undefined) => {
     loading: loading || (!!sourceWallet && !result && !error),
     error,
     reload: execute,
-    hotspots: result?.hotspots ?? NO_HOTSPOTS,
-    tokens: result?.tokens ?? NO_TOKENS,
-    leftBehindMints: result?.leftBehindMints ?? NO_MINTS,
+    hotspots: result ?? NO_HOTSPOTS,
+    tokens: migratableTokens,
+    leftBehindMints,
   }
 }

--- a/src/features/migration/hooks/useTokenDisplay.ts
+++ b/src/features/migration/hooks/useTokenDisplay.ts
@@ -1,0 +1,14 @@
+import { useMetaplexMetadata } from '@hooks/useMetaplexMetadata'
+import { usePublicKey } from '@hooks/usePublicKey'
+
+// Holdings carry no metadata, so every row resolves its own: symbol, then name,
+// then the shortened-mint fallback the classifier supplied. Shared by the token
+// sheet and the review lines so both name a token the same way.
+export const useTokenDisplay = (
+  mint: string,
+  fallbackLabel: string,
+): { label: string; image?: string } => {
+  const { json, symbol, name } = useMetaplexMetadata(usePublicKey(mint))
+
+  return { label: symbol || name || fallbackLabel, image: json?.image }
+}

--- a/src/features/migration/logic/__tests__/assets.test.ts
+++ b/src/features/migration/logic/__tests__/assets.test.ts
@@ -9,7 +9,7 @@ describe('classifyHoldings', () => {
     const r = classifyHoldings({
       holdings: [{ mint: UNKNOWN, balance: 5000000, decimals: 6 }],
       visibleTokens: new Set([UNKNOWN]),
-      solBalance: 0,
+      solLamports: 0,
     })
     expect(r.migratableTokens).toMatchObject([
       { mint: UNKNOWN, decimals: 6, maxUi: '5' },
@@ -17,21 +17,21 @@ describe('classifyHoldings', () => {
     expect(r.leftBehindMints).toEqual([])
   })
 
-  it('prepends native SOL as WSOL when solBalance > 0', () => {
+  it('prepends native SOL as WSOL when solLamports > 0', () => {
     const r = classifyHoldings({
       holdings: [],
       visibleTokens: new Set<string>(),
-      solBalance: 1.5,
+      solLamports: 1500000000,
     })
     expect(r.migratableTokens[0].mint).toBe(WSOL_MINT)
     expect(r.migratableTokens[0].maxUi).toBe('1.5')
   })
 
-  it('omits native SOL when solBalance is 0', () => {
+  it('omits native SOL when solLamports is 0', () => {
     const r = classifyHoldings({
       holdings: [],
       visibleTokens: new Set<string>(),
-      solBalance: 0,
+      solLamports: 0,
     })
     expect(r.migratableTokens).toHaveLength(0)
   })
@@ -40,7 +40,7 @@ describe('classifyHoldings', () => {
     const r = classifyHoldings({
       holdings: [{ mint: HNT, balance: 142500000000, decimals: 9 }],
       visibleTokens: new Set([HNT]),
-      solBalance: 0,
+      solLamports: 0,
     })
     expect(r.migratableTokens).toMatchObject([
       { mint: HNT, label: 'hnty…xWux', maxUi: '142.5' },
@@ -54,7 +54,7 @@ describe('classifyHoldings', () => {
         { mint: HNT, balance: 10, decimals: 9 }, // visible → offered
       ],
       visibleTokens: new Set([HNT]),
-      solBalance: 0,
+      solLamports: 0,
     })
     expect(r.migratableTokens.map((tk) => tk.mint)).toEqual([HNT])
     expect(r.leftBehindMints).toEqual([UNKNOWN])
@@ -64,7 +64,7 @@ describe('classifyHoldings', () => {
     const r = classifyHoldings({
       holdings: [{ mint: WSOL_MINT, balance: 5000, decimals: 9 }],
       visibleTokens: new Set([WSOL_MINT]),
-      solBalance: 0,
+      solLamports: 0,
     })
     expect(r.migratableTokens).toEqual([])
     expect(r.leftBehindMints).toEqual([WSOL_MINT])
@@ -74,7 +74,7 @@ describe('classifyHoldings', () => {
     const r = classifyHoldings({
       holdings: [{ mint: HNT, balance: 10, decimals: 9, frozen: true }],
       visibleTokens: new Set([HNT]),
-      solBalance: 0,
+      solLamports: 0,
     })
     expect(r.migratableTokens).toEqual([])
     expect(r.leftBehindMints).toEqual([HNT])
@@ -88,7 +88,7 @@ describe('classifyHoldings', () => {
         { mint: UNKNOWN, balance: 5000, decimals: 6 },
       ],
       visibleTokens: new Set([NFT]),
-      solBalance: 0,
+      solLamports: 0,
     })
     expect(r.migratableTokens).toEqual([])
     expect(r.leftBehindMints).toEqual([UNKNOWN])
@@ -98,7 +98,7 @@ describe('classifyHoldings', () => {
     const r = classifyHoldings({
       holdings: [{ mint: UNKNOWN, balance: 42, decimals: 0 }],
       visibleTokens: new Set<string>(),
-      solBalance: 0,
+      solLamports: 0,
     })
     expect(r.migratableTokens).toEqual([])
     expect(r.leftBehindMints).toEqual([])
@@ -109,7 +109,7 @@ describe('classifyHoldings', () => {
     const r = classifyHoldings({
       holdings: [{ mint: DC, balance: 1, decimals: 0, frozen: true }],
       visibleTokens: new Set([DC]),
-      solBalance: 0,
+      solLamports: 0,
     })
     expect(r.leftBehindMints).toEqual([DC])
   })
@@ -118,7 +118,7 @@ describe('classifyHoldings', () => {
     const r = classifyHoldings({
       holdings: [{ mint: UNKNOWN, balance: 0, decimals: 6 }],
       visibleTokens: new Set([UNKNOWN]),
-      solBalance: 0,
+      solLamports: 0,
     })
     expect(r.migratableTokens).toEqual([])
     expect(r.leftBehindMints).toEqual([])

--- a/src/features/migration/logic/__tests__/assets.test.ts
+++ b/src/features/migration/logic/__tests__/assets.test.ts
@@ -60,6 +60,16 @@ describe('classifyHoldings', () => {
     expect(r.leftBehindMints).toEqual([UNKNOWN])
   })
 
+  it('leaves behind a wrapped-SOL ATA with a balance', () => {
+    const r = classifyHoldings({
+      holdings: [{ mint: WSOL_MINT, balance: 5000, decimals: 9 }],
+      visibleTokens: new Set([WSOL_MINT]),
+      solBalance: 0,
+    })
+    expect(r.migratableTokens).toEqual([])
+    expect(r.leftBehindMints).toEqual([WSOL_MINT])
+  })
+
   it('leaves behind a frozen holding even when it is visible', () => {
     const r = classifyHoldings({
       holdings: [{ mint: HNT, balance: 10, decimals: 9, frozen: true }],

--- a/src/features/migration/logic/__tests__/assets.test.ts
+++ b/src/features/migration/logic/__tests__/assets.test.ts
@@ -80,7 +80,7 @@ describe('classifyHoldings', () => {
     expect(r.leftBehindMints).toEqual([HNT])
   })
 
-  it('ignores NFT-shaped holdings (decimals 0, balance 1) in both lists', () => {
+  it('ignores NFT-shaped holdings (decimals 0) in both lists', () => {
     const NFT = 'NFTmint11111111111111111111111111111111111'
     const r = classifyHoldings({
       holdings: [
@@ -94,13 +94,24 @@ describe('classifyHoldings', () => {
     expect(r.leftBehindMints).toEqual([UNKNOWN])
   })
 
-  it('keeps decimals-0 fungible balances above 1 as left behind', () => {
+  it('treats any decimals-0 holding as an NFT, like the account token list', () => {
     const r = classifyHoldings({
       holdings: [{ mint: UNKNOWN, balance: 42, decimals: 0 }],
       visibleTokens: new Set<string>(),
       solBalance: 0,
     })
-    expect(r.leftBehindMints).toEqual([UNKNOWN])
+    expect(r.migratableTokens).toEqual([])
+    expect(r.leftBehindMints).toEqual([])
+  })
+
+  it('keeps DC as a fungible token despite its zero decimals', () => {
+    const DC = 'dcuc8Amr83Wz27ZkQ2K9NS6r8zRpf1J6cvArEBDZDmm'
+    const r = classifyHoldings({
+      holdings: [{ mint: DC, balance: 1, decimals: 0, frozen: true }],
+      visibleTokens: new Set([DC]),
+      solBalance: 0,
+    })
+    expect(r.leftBehindMints).toEqual([DC])
   })
 
   it('omits zero-balance holdings from both lists', () => {

--- a/src/features/migration/logic/__tests__/assets.test.ts
+++ b/src/features/migration/logic/__tests__/assets.test.ts
@@ -5,82 +5,101 @@ const HNT = 'hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux'
 const UNKNOWN = 'FAKEmint1111111111111111111111111111111111'
 
 describe('classifyHoldings', () => {
+  it('offers a visible, non-frozen holding with a balance', () => {
+    const r = classifyHoldings({
+      holdings: [{ mint: UNKNOWN, balance: 5000000, decimals: 6 }],
+      visibleTokens: new Set([UNKNOWN]),
+      solBalance: 0,
+    })
+    expect(r.migratableTokens).toMatchObject([
+      { mint: UNKNOWN, decimals: 6, maxUi: '5' },
+    ])
+    expect(r.leftBehindMints).toEqual([])
+  })
+
   it('prepends native SOL as WSOL when solBalance > 0', () => {
     const r = classifyHoldings({
-      migratable: [],
-      solBalance: 1.5,
       holdings: [],
+      visibleTokens: new Set<string>(),
+      solBalance: 1.5,
     })
     expect(r.migratableTokens[0].mint).toBe(WSOL_MINT)
     expect(r.migratableTokens[0].maxUi).toBe('1.5')
   })
 
   it('omits native SOL when solBalance is 0', () => {
-    const r = classifyHoldings({ migratable: [], solBalance: 0, holdings: [] })
+    const r = classifyHoldings({
+      holdings: [],
+      visibleTokens: new Set<string>(),
+      solBalance: 0,
+    })
     expect(r.migratableTokens).toHaveLength(0)
   })
 
-  it('includes migratable tokens with a readable label', () => {
+  it('labels a holding with its shortened mint', () => {
     const r = classifyHoldings({
-      migratable: [
-        {
-          mint: HNT,
-          balance: '142500000000',
-          decimals: 9,
-          uiAmount: 142.5,
-          symbol: 'HNT',
-        },
-      ],
+      holdings: [{ mint: HNT, balance: 142500000000, decimals: 9 }],
+      visibleTokens: new Set([HNT]),
       solBalance: 0,
-      holdings: [],
     })
-    const hnt = r.migratableTokens.find((t) => t.mint === HNT)
-    expect(hnt).toMatchObject({
-      label: 'HNT',
-      maxUi: '142.5',
-    })
+    expect(r.migratableTokens).toMatchObject([
+      { mint: HNT, label: 'hnty…xWux', maxUi: '142.5' },
+    ])
   })
 
-  it('flags nonzero holdings of unsupported mints as left behind', () => {
+  it('leaves behind a hidden holding with a balance', () => {
     const r = classifyHoldings({
-      migratable: [],
-      solBalance: 0,
       holdings: [
         { mint: UNKNOWN, balance: 5000, decimals: 6 },
-        { mint: HNT, balance: 10, decimals: 9 }, // supported → not flagged
+        { mint: HNT, balance: 10, decimals: 9 }, // visible → offered
       ],
+      visibleTokens: new Set([HNT]),
+      solBalance: 0,
     })
+    expect(r.migratableTokens.map((tk) => tk.mint)).toEqual([HNT])
     expect(r.leftBehindMints).toEqual([UNKNOWN])
   })
 
-  it('excludes NFT-shaped holdings (decimals 0, balance 1) from left behind', () => {
+  it('leaves behind a frozen holding even when it is visible', () => {
+    const r = classifyHoldings({
+      holdings: [{ mint: HNT, balance: 10, decimals: 9, frozen: true }],
+      visibleTokens: new Set([HNT]),
+      solBalance: 0,
+    })
+    expect(r.migratableTokens).toEqual([])
+    expect(r.leftBehindMints).toEqual([HNT])
+  })
+
+  it('ignores NFT-shaped holdings (decimals 0, balance 1) in both lists', () => {
     const NFT = 'NFTmint11111111111111111111111111111111111'
     const r = classifyHoldings({
-      migratable: [],
-      solBalance: 0,
       holdings: [
         { mint: NFT, balance: 1, decimals: 0 }, // NFT → not a token
         { mint: UNKNOWN, balance: 5000, decimals: 6 },
       ],
+      visibleTokens: new Set([NFT]),
+      solBalance: 0,
     })
+    expect(r.migratableTokens).toEqual([])
     expect(r.leftBehindMints).toEqual([UNKNOWN])
   })
 
   it('keeps decimals-0 fungible balances above 1 as left behind', () => {
     const r = classifyHoldings({
-      migratable: [],
-      solBalance: 0,
       holdings: [{ mint: UNKNOWN, balance: 42, decimals: 0 }],
+      visibleTokens: new Set<string>(),
+      solBalance: 0,
     })
     expect(r.leftBehindMints).toEqual([UNKNOWN])
   })
 
-  it('ignores zero-balance unsupported holdings', () => {
+  it('omits zero-balance holdings from both lists', () => {
     const r = classifyHoldings({
-      migratable: [],
-      solBalance: 0,
       holdings: [{ mint: UNKNOWN, balance: 0, decimals: 6 }],
+      visibleTokens: new Set([UNKNOWN]),
+      solBalance: 0,
     })
+    expect(r.migratableTokens).toEqual([])
     expect(r.leftBehindMints).toEqual([])
   })
 })

--- a/src/features/migration/logic/__tests__/fiat.test.ts
+++ b/src/features/migration/logic/__tests__/fiat.test.ts
@@ -73,15 +73,4 @@ describe('estimateFiat', () => {
       }),
     ).toEqual({ total: 10, unpricedCount: 0 })
   })
-
-  it('counts every selected mint as unpriced when prices have not loaded', () => {
-    expect(
-      estimateFiat({
-        tokens: [token(WSOL_MINT), token(HNT)],
-        amounts: { [WSOL_MINT]: '1', [HNT]: '2' },
-        prices: undefined,
-        currency: 'usd',
-      }),
-    ).toEqual({ total: 0, unpricedCount: 2 })
-  })
 })

--- a/src/features/migration/logic/__tests__/fiat.test.ts
+++ b/src/features/migration/logic/__tests__/fiat.test.ts
@@ -1,0 +1,87 @@
+import { HNT_MINT } from '@helium/spl-utils'
+import { estimateFiat } from '../fiat'
+import { WSOL_MINT } from '../mints'
+
+const HNT = HNT_MINT.toBase58()
+const ARBITRARY_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+const OTHER_MINT = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB'
+
+const token = (mint: string) => ({
+  mint,
+  label: mint,
+  decimals: 9,
+  maxUi: '1',
+})
+
+const prices = {
+  solana: { usd: 150 },
+  helium: { usd: 5 },
+}
+
+describe('estimateFiat', () => {
+  it('totals the selected amounts when every mint is priced', () => {
+    expect(
+      estimateFiat({
+        tokens: [token(WSOL_MINT), token(HNT)],
+        amounts: { [WSOL_MINT]: '1', [HNT]: '2' },
+        prices,
+        currency: 'usd',
+      }),
+    ).toEqual({ total: 160, unpricedCount: 0 })
+  })
+
+  it('totals only the priced mints and counts the rest', () => {
+    expect(
+      estimateFiat({
+        tokens: [token(HNT), token(ARBITRARY_MINT)],
+        amounts: { [HNT]: '3', [ARBITRARY_MINT]: '1000' },
+        prices,
+        currency: 'usd',
+      }),
+    ).toEqual({ total: 15, unpricedCount: 1 })
+  })
+
+  it('returns a zero total when nothing selected is priced', () => {
+    expect(
+      estimateFiat({
+        tokens: [token(ARBITRARY_MINT), token(OTHER_MINT)],
+        amounts: { [ARBITRARY_MINT]: '1', [OTHER_MINT]: '2' },
+        prices,
+        currency: 'usd',
+      }),
+    ).toEqual({ total: 0, unpricedCount: 2 })
+  })
+
+  it('counts a priced mint with no entry for the current currency as unpriced', () => {
+    expect(
+      estimateFiat({
+        tokens: [token(WSOL_MINT), token(HNT)],
+        amounts: { [WSOL_MINT]: '1', [HNT]: '2' },
+        prices: { solana: { usd: 150 }, helium: {} },
+        currency: 'usd',
+      }),
+    ).toEqual({ total: 150, unpricedCount: 1 })
+  })
+
+  it('ignores tokens with no amount selected', () => {
+    expect(
+      estimateFiat({
+        tokens: [token(HNT), token(ARBITRARY_MINT)],
+        amounts: { [HNT]: '2', [ARBITRARY_MINT]: '0' },
+        prices,
+        currency: 'usd',
+      }),
+    ).toEqual({ total: 10, unpricedCount: 0 })
+  })
+
+  it('counts every selected mint as unpriced when prices have not loaded', () => {
+    expect(
+      estimateFiat({
+        tokens: [token(WSOL_MINT), token(HNT)],
+        amounts: { [WSOL_MINT]: '1', [HNT]: '2' },
+        prices: undefined,
+        currency: 'usd',
+      }),
+    ).toEqual({ total: 0, unpricedCount: 2 })
+  })
+})

--- a/src/features/migration/logic/assets.ts
+++ b/src/features/migration/logic/assets.ts
@@ -22,15 +22,12 @@ export const nothingToMigrate = (
   tokens: unknown[],
 ): boolean => !loading && hotspots.length === 0 && tokens.length === 0
 
-const solToSelectable = (solBalance: number): SelectableToken => {
-  const raw = String(Math.round(solBalance * 1e9))
-  return {
-    mint: WSOL_MINT,
-    label: 'SOL',
-    decimals: 9,
-    maxUi: rawToUi(raw, 9),
-  }
-}
+const solToSelectable = (solLamports: bigint | number): SelectableToken => ({
+  mint: WSOL_MINT,
+  label: 'SOL',
+  decimals: 9,
+  maxUi: rawToUi(String(solLamports), 9),
+})
 
 // Holdings carry no metadata, so the label is only ever the fallback; the token
 // rows and review lines resolve symbol/name from the metadata hook on top.
@@ -44,9 +41,9 @@ const holdingToSelectable = (h: WalletHolding): SelectableToken => ({
 export const classifyHoldings = (args: {
   holdings: WalletHolding[]
   visibleTokens: ReadonlySet<string>
-  solBalance: number
+  solLamports: bigint | number
 }): HoldingsClassification => {
-  const { holdings, visibleTokens, solBalance } = args
+  const { holdings, visibleTokens, solLamports } = args
 
   // tokenAccounts includes NFT ATAs, which aren't tokens and belong in neither
   // the offer nor the warning.
@@ -61,7 +58,7 @@ export const classifyHoldings = (args: {
   const byMint = new Map(fungible.map((h) => [h.mint, h]))
 
   const migratableTokens: SelectableToken[] = [
-    ...(solBalance > 0 ? [solToSelectable(solBalance)] : []),
+    ...(solLamports > 0 ? [solToSelectable(solLamports)] : []),
     // The native SOL row already occupies the WSOL mint key.
     ...visibleMints
       .filter((mint) => mint !== WSOL_MINT)

--- a/src/features/migration/logic/assets.ts
+++ b/src/features/migration/logic/assets.ts
@@ -60,7 +60,7 @@ export const classifyHoldings = (args: {
 
   const migratableTokens: SelectableToken[] = [
     ...(solBalance > 0 ? [solToSelectable(solBalance)] : []),
-    // A wrapped-SOL ATA is skipped: the native SOL row already occupies that mint.
+    // The native SOL row already occupies the WSOL mint key.
     ...visibleMints
       .filter((mint) => mint !== WSOL_MINT)
       .flatMap((mint) => {
@@ -69,11 +69,13 @@ export const classifyHoldings = (args: {
       }),
   ]
 
+  // A wrapped-SOL ATA is also left behind: the server reads the WSOL mint as
+  // native SOL, so the ATA balance cannot move through this endpoint.
   const visible = new Set(visibleMints)
   const leftBehindMints = Array.from(
     new Set(
       fungible
-        .filter((h) => h.frozen || !visible.has(h.mint))
+        .filter((h) => h.frozen || h.mint === WSOL_MINT || !visible.has(h.mint))
         .map((h) => h.mint),
     ),
   )

--- a/src/features/migration/logic/assets.ts
+++ b/src/features/migration/logic/assets.ts
@@ -1,4 +1,7 @@
-import { deriveVisibleMints } from '../../account/logic/visibleTokens'
+import {
+  deriveVisibleMints,
+  isNftLike,
+} from '../../account/logic/visibleTokens'
 import { rawToUi } from './amounts'
 import { WSOL_MINT } from './mints'
 import { HoldingsClassification, SelectableToken, WalletHolding } from './types'
@@ -45,10 +48,9 @@ export const classifyHoldings = (args: {
 }): HoldingsClassification => {
   const { holdings, visibleTokens, solBalance } = args
 
-  // tokenAccounts includes NFT ATAs (decimals 0, supply 1), which aren't tokens
-  // and belong in neither the offer nor the warning.
-  const isNft = (h: WalletHolding) => h.decimals === 0 && h.balance === 1
-  const fungible = holdings.filter((h) => h.balance > 0 && !isNft(h))
+  // tokenAccounts includes NFT ATAs, which aren't tokens and belong in neither
+  // the offer nor the warning.
+  const fungible = holdings.filter((h) => h.balance > 0 && !isNftLike(h))
 
   // Same derivation the account token list uses, so the flow offers exactly the
   // tokens the user already sees. It orders network tokens first.

--- a/src/features/migration/logic/assets.ts
+++ b/src/features/migration/logic/assets.ts
@@ -1,11 +1,7 @@
+import { deriveVisibleMints } from '../../account/logic/visibleTokens'
 import { rawToUi } from './amounts'
-import { MIGRATABLE_MINTS, WSOL_MINT } from './mints'
-import {
-  HoldingsClassification,
-  MigratableToken,
-  SelectableToken,
-  WalletHolding,
-} from './types'
+import { WSOL_MINT } from './mints'
+import { HoldingsClassification, SelectableToken, WalletHolding } from './types'
 
 // Local (not @utils/formatting's shortenAddress): logic/ runs under node-jest,
 // and that module's import chain drags react-native-localize, which the node
@@ -33,35 +29,51 @@ const solToSelectable = (solBalance: number): SelectableToken => {
   }
 }
 
-const tokenToSelectable = (t: MigratableToken): SelectableToken => ({
-  mint: t.mint,
-  label: t.symbol || t.name || shortenMint(t.mint),
-  decimals: t.decimals,
-  maxUi: rawToUi(t.balance, t.decimals),
+// Holdings carry no metadata, so the label is only ever the fallback; the token
+// rows and review lines resolve symbol/name from the metadata hook on top.
+const holdingToSelectable = (h: WalletHolding): SelectableToken => ({
+  mint: h.mint,
+  label: shortenMint(h.mint),
+  decimals: h.decimals,
+  maxUi: rawToUi(String(h.balance), h.decimals),
 })
 
 export const classifyHoldings = (args: {
-  migratable: MigratableToken[]
-  solBalance: number
   holdings: WalletHolding[]
+  visibleTokens: ReadonlySet<string>
+  solBalance: number
 }): HoldingsClassification => {
-  const { migratable, solBalance, holdings } = args
+  const { holdings, visibleTokens, solBalance } = args
+
+  // tokenAccounts includes NFT ATAs (decimals 0, supply 1), which aren't tokens
+  // and belong in neither the offer nor the warning.
+  const isNft = (h: WalletHolding) => h.decimals === 0 && h.balance === 1
+  const fungible = holdings.filter((h) => h.balance > 0 && !isNft(h))
+
+  // Same derivation the account token list uses, so the flow offers exactly the
+  // tokens the user already sees. It orders network tokens first.
+  const visibleMints = deriveVisibleMints({
+    tokenAccounts: holdings,
+    visibleTokens,
+  })
+  const byMint = new Map(fungible.map((h) => [h.mint, h]))
 
   const migratableTokens: SelectableToken[] = [
     ...(solBalance > 0 ? [solToSelectable(solBalance)] : []),
-    ...migratable.filter((t) => t.uiAmount > 0).map(tokenToSelectable),
+    // A wrapped-SOL ATA is skipped: the native SOL row already occupies that mint.
+    ...visibleMints
+      .filter((mint) => mint !== WSOL_MINT)
+      .flatMap((mint) => {
+        const holding = byMint.get(mint)
+        return holding && !holding.frozen ? [holdingToSelectable(holding)] : []
+      }),
   ]
 
-  // The warning counts fungible tokens that can't move. tokenAccounts includes
-  // NFT ATAs (decimals 0, supply 1) which aren't tokens, so exclude them.
-  const isNft = (h: WalletHolding) => h.decimals === 0 && h.balance === 1
-
+  const visible = new Set(visibleMints)
   const leftBehindMints = Array.from(
     new Set(
-      holdings
-        .filter(
-          (h) => h.balance > 0 && !MIGRATABLE_MINTS.has(h.mint) && !isNft(h),
-        )
+      fungible
+        .filter((h) => h.frozen || !visible.has(h.mint))
         .map((h) => h.mint),
     ),
   )

--- a/src/features/migration/logic/fiat.ts
+++ b/src/features/migration/logic/fiat.ts
@@ -1,0 +1,28 @@
+import { MINT_PRICE_KEY } from './mints'
+import { FiatEstimate, PriceMap, SelectableToken } from './types'
+
+// Sums the selected amounts over the mints we can price and counts the rest,
+// so an arbitrary token never silently shrinks the estimate.
+export const estimateFiat = (args: {
+  tokens: SelectableToken[]
+  amounts: Record<string, string>
+  prices?: PriceMap
+  currency: string
+}): FiatEstimate => {
+  const { tokens, amounts, prices, currency } = args
+
+  let total = 0
+  let unpricedCount = 0
+
+  tokens.forEach((tk) => {
+    const amount = parseFloat(amounts[tk.mint] ?? '')
+    if (!(amount > 0)) return
+
+    const priceKey = MINT_PRICE_KEY[tk.mint]
+    const price = priceKey ? prices?.[priceKey]?.[currency] : undefined
+    if (price === undefined) unpricedCount += 1
+    else total += price * amount
+  })
+
+  return { total, unpricedCount }
+}

--- a/src/features/migration/logic/fiat.ts
+++ b/src/features/migration/logic/fiat.ts
@@ -6,7 +6,7 @@ import { FiatEstimate, PriceMap, SelectableToken } from './types'
 export const estimateFiat = (args: {
   tokens: SelectableToken[]
   amounts: Record<string, string>
-  prices?: PriceMap
+  prices: PriceMap
   currency: string
 }): FiatEstimate => {
   const { tokens, amounts, prices, currency } = args
@@ -19,7 +19,7 @@ export const estimateFiat = (args: {
     if (!(amount > 0)) return
 
     const priceKey = MINT_PRICE_KEY[tk.mint]
-    const price = priceKey ? prices?.[priceKey]?.[currency] : undefined
+    const price = priceKey ? prices[priceKey]?.[currency] : undefined
     if (price === undefined) unpricedCount += 1
     else total += price * amount
   })

--- a/src/features/migration/logic/mints.ts
+++ b/src/features/migration/logic/mints.ts
@@ -1,29 +1,16 @@
-import { DC_MINT, HNT_MINT, IOT_MINT, MOBILE_MINT } from '@helium/spl-utils'
+import { HNT_MINT, IOT_MINT, MOBILE_MINT } from '@helium/spl-utils'
 import { NATIVE_MINT } from '@solana/spl-token'
 
-// Mint addresses the migration backend supports. SOL/HNT/MOBILE/IOT/DC come from
-// the canonical Helium/Solana constants; only USDC/USDT (not exported by those
-// packages) stay as literals.
+// Mint addresses the migration flow prices. They come from the canonical
+// Helium/Solana constants.
 export const WSOL_MINT = NATIVE_MINT.toBase58()
 const HNT = HNT_MINT.toBase58()
 const MOBILE = MOBILE_MINT.toBase58()
 const IOT = IOT_MINT.toBase58()
-const DC = DC_MINT.toBase58()
-const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
-const USDT_MINT = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB'
-
-export const MIGRATABLE_MINTS: ReadonlySet<string> = new Set([
-  WSOL_MINT,
-  USDC_MINT,
-  USDT_MINT,
-  HNT,
-  MOBILE,
-  IOT,
-  DC,
-])
 
 // Maps a migratable mint to its coingecko key in redux `balances.tokenPrices`.
-// Only mints we have a price feed for appear here (USDC/USDT/DC are omitted).
+// Only mints we have a price feed for appear here; every other token counts as
+// unpriced.
 export const MINT_PRICE_KEY: Readonly<Record<string, string>> = {
   [WSOL_MINT]: 'solana',
   [HNT]: 'helium',

--- a/src/features/migration/logic/types.ts
+++ b/src/features/migration/logic/types.ts
@@ -42,3 +42,13 @@ export type HoldingsClassification = {
   migratableTokens: SelectableToken[]
   leftBehindMints: string[] // mints the wallet holds (nonzero) but cannot migrate
 }
+
+// Redux `balances.tokenPrices`: price key -> currency code -> price.
+export type PriceMap = Readonly<
+  Record<string, Record<string, number> | undefined>
+>
+
+export type FiatEstimate = {
+  total: number // over the priced mints only
+  unpricedCount: number // selected mints with no price in this currency
+}

--- a/src/features/migration/logic/types.ts
+++ b/src/features/migration/logic/types.ts
@@ -1,3 +1,5 @@
+import { VisibleTokenAccount } from '../../account/logic/visibleTokens'
+
 // Structural types describing only the fields the pure logic consumes.
 // Real client objects (blockchain-api oRPC) satisfy these by shape.
 
@@ -23,21 +25,10 @@ export type TransactionData = {
   tag?: string
 }
 
-// A migratable token as returned by tokens.getBalances (subset).
-export type MigratableToken = {
-  mint: string
-  balance: string // raw integer string
-  decimals: number
-  uiAmount: number
-  symbol?: string
-  name?: string
-}
-
-// A raw wallet ATA holding, from useBalance().tokenAccounts.
-export type WalletHolding = {
-  mint: string
-  balance: number // raw integer amount
-  decimals: number
+// A raw wallet ATA holding, from useBalance().tokenAccounts. frozen is absent
+// on state persisted before that field existed, which reads as not frozen.
+export type WalletHolding = VisibleTokenAccount & {
+  frozen?: boolean
 }
 
 export type SelectableToken = {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1643,6 +1643,7 @@ export default {
       loading: 'Loading assets…',
       review: 'Review migration',
       approxValue: '≈ {{value}}',
+      approxValueUnpriced: '≈ {{value}} + {{unpriced}} unpriced',
       loadErrorTitle: "Couldn't load your assets",
       loadErrorBody:
         'Something went wrong loading your assets. Check your connection and try again.',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1638,6 +1638,8 @@ export default {
         "{{count}} tokens can't move automatically. They stay in your wallet.",
       leftBehind_plural:
         "{{count}} tokens can't move automatically. They stay in your wallet.",
+      leftBehindHint:
+        'To include a hidden token, make it visible in Manage Visible Tokens.',
       loading: 'Loading assets…',
       review: 'Review migration',
       approxValue: '≈ {{value}}',

--- a/src/storage/TokensProvider.tsx
+++ b/src/storage/TokensProvider.tsx
@@ -1,5 +1,3 @@
-import { DC_MINT, HNT_MINT, IOT_MINT, MOBILE_MINT } from '@helium/spl-utils'
-import { NATIVE_MINT } from '@solana/spl-token'
 import { PublicKey } from '@solana/web3.js'
 import React, {
   ReactNode,
@@ -9,6 +7,7 @@ import React, {
   useState,
 } from 'react'
 import { useAsync } from 'react-async-hook'
+import { DEFAULT_TOKENS } from '../features/account/logic/visibleTokens'
 import * as Logger from '../utils/logger'
 import { useAccountStorage } from './AccountStorageProvider'
 import {
@@ -16,16 +15,6 @@ import {
   restoreVisibleTokens,
   updateVisibleTokens,
 } from './cloudStorage'
-
-const USDC_MINT = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
-export const DEFAULT_TOKENS = new Set([
-  HNT_MINT.toBase58(),
-  MOBILE_MINT.toBase58(),
-  IOT_MINT.toBase58(),
-  DC_MINT.toBase58(),
-  NATIVE_MINT.toBase58(),
-  USDC_MINT.toBase58(),
-])
 
 const useVisibleTokensHook = () => {
   const { currentAccount } = useAccountStorage()

--- a/src/store/logic/__tests__/tokenAccounts.test.ts
+++ b/src/store/logic/__tests__/tokenAccounts.test.ts
@@ -1,0 +1,72 @@
+import { AccountLayout, AccountState } from '@solana/spl-token'
+import { PublicKey } from '@solana/web3.js'
+import { decodeTokenAccount } from '../tokenAccounts'
+
+const HNT_MINT = new PublicKey('hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux')
+const OWNER = new PublicKey('11111111111111111111111111111111')
+
+const encodeAccount = (args: {
+  mint: PublicKey
+  amount: bigint
+  state: AccountState
+}): Buffer => {
+  const data = Buffer.alloc(AccountLayout.span)
+  AccountLayout.encode(
+    {
+      mint: args.mint,
+      owner: OWNER,
+      amount: args.amount,
+      delegateOption: 0,
+      delegate: PublicKey.default,
+      delegatedAmount: BigInt(0),
+      state: args.state,
+      isNativeOption: 0,
+      isNative: BigInt(0),
+      closeAuthorityOption: 0,
+      closeAuthority: PublicKey.default,
+    },
+    data,
+  )
+  return data
+}
+
+describe('decodeTokenAccount', () => {
+  it('reads a frozen account as frozen', () => {
+    const decoded = decodeTokenAccount(
+      encodeAccount({
+        mint: HNT_MINT,
+        amount: BigInt(500),
+        state: AccountState.Frozen,
+      }),
+    )
+
+    expect(decoded.frozen).toBe(true)
+  })
+
+  it('reads an initialized account as not frozen', () => {
+    const decoded = decodeTokenAccount(
+      encodeAccount({
+        mint: HNT_MINT,
+        amount: BigInt(500),
+        state: AccountState.Initialized,
+      }),
+    )
+
+    expect(decoded.frozen).toBe(false)
+  })
+
+  it('reads the mint and raw amount', () => {
+    const decoded = decodeTokenAccount(
+      encodeAccount({
+        mint: HNT_MINT,
+        amount: BigInt(12345678),
+        state: AccountState.Initialized,
+      }),
+    )
+
+    expect(decoded.mint.toBase58()).toBe(
+      'hntyVP6YFm1Hg25TN9WGLqM12b8TQmcknKrdu1oxWux',
+    )
+    expect(decoded.amount).toBe(BigInt(12345678))
+  })
+})

--- a/src/store/logic/tokenAccounts.ts
+++ b/src/store/logic/tokenAccounts.ts
@@ -1,0 +1,20 @@
+import { AccountLayout, AccountState } from '@solana/spl-token'
+import { PublicKey } from '@solana/web3.js'
+
+export type DecodedTokenAccount = {
+  mint: PublicKey
+  amount: bigint
+  frozen: boolean
+}
+
+// Balance sync only reads the fields the stored token account keeps. Frozen
+// accounts (e.g. Data Credits) can't be transferred, so flows that move tokens
+// need the account state alongside the balance.
+export const decodeTokenAccount = (data: Buffer): DecodedTokenAccount => {
+  const account = AccountLayout.decode(data)
+  return {
+    mint: account.mint,
+    amount: account.amount,
+    frozen: account.state === AccountState.Frozen,
+  }
+}

--- a/src/store/slices/balancesSlice.ts
+++ b/src/store/slices/balancesSlice.ts
@@ -1,10 +1,11 @@
 import { AnchorProvider } from '@coral-xyz/anchor'
 import { PayloadAction, createAsyncThunk, createSlice } from '@reduxjs/toolkit'
-import { AccountLayout, TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import { Cluster, PublicKey } from '@solana/web3.js'
 import { PURGE } from 'redux-persist'
 import { CSAccount } from '../../storage/cloudStorage'
 import { AccountBalance, Prices, TokenAccount } from '../../types/balance'
+import { decodeTokenAccount } from '../logic/tokenAccounts'
 import { getBalanceHistory, getTokenPrices } from '../../utils/walletApiV2'
 import { SyncGuard } from '../../utils/syncGuard'
 
@@ -75,14 +76,10 @@ export const syncTokenAccounts = createAsyncThunk(
       const solAcct = await connection.getAccountInfo(pubKey)
 
       // Decode all token account data first
-      const tokenAccountsData = tokenAccounts.value.map((tokenAccount) => {
-        const accountData = AccountLayout.decode(tokenAccount.account.data)
-        return {
-          pubkey: tokenAccount.pubkey,
-          mint: accountData.mint,
-          amount: accountData.amount,
-        }
-      })
+      const tokenAccountsData = tokenAccounts.value.map((tokenAccount) => ({
+        pubkey: tokenAccount.pubkey,
+        ...decodeTokenAccount(tokenAccount.account.data),
+      }))
 
       // Extract unique mints and batch fetch their info using getMultipleAccountsInfo
       // Cap at 100 accounts per request due to RPC limits
@@ -146,6 +143,7 @@ export const syncTokenAccounts = createAsyncThunk(
           mint: tokenAccountData.mint.toBase58(),
           balance: Number(tokenAccountData.amount || 0),
           decimals: mintInfoMap.get(tokenAccountData.mint.toBase58()) || 0,
+          frozen: tokenAccountData.frozen,
         }),
       )
 

--- a/src/types/balance.ts
+++ b/src/types/balance.ts
@@ -3,6 +3,10 @@ export type TokenAccount = {
   mint: string
   balance: number
   decimals: number
+  // Frozen accounts (e.g. Data Credits) can't be transferred, so flows that
+  // move tokens must skip them. Absent on state written before this field
+  // existed, which reads as not frozen.
+  frozen: boolean
 }
 
 export type AccountBalance = {


### PR DESCRIPTION
## Summary

The Migrate to World flow offers every visible token with a balance, built from local holdings instead of the server's token list. Hidden and frozen holdings are counted in the left-behind warning with a hint to Manage Tokens. The `migration.migrate` request shape is unchanged.

Commits, one per ticket:

- `48ac1596` **refactor: extract visible-token derivation** — `deriveVisibleMints` in `src/features/account/logic/visibleTokens.ts`; the account token list uses it and keeps its exact output (fixture test). `DEFAULT_TOKENS` moves here from `TokensProvider`.
- `7c4b9191` **feat: store `frozen` on token accounts** — decoded from SPL `AccountState` during balance sync. `balances` is persist-blacklisted, so no Redux Persist migration is needed.
- `98a6d3e1` **feat: offer every visible token in migration** — `classifyHoldings` rebuilt on `deriveVisibleMints` + `frozen`; `tokens.getBalances` removed from `useMigrationAssets` (hotspots still from server); `useTokenDisplay` for icon/symbol/name/shortened-mint labels; `MIGRATABLE_MINTS` and `MigratableToken` deleted.
- `134391ec` **feat: fiat estimate counts unpriced tokens** — pure `estimateFiat` → `{ total, unpricedCount }`; subtitle reads "≈ $X" or "≈ $X + N unpriced".

## Verification

- `yarn test`: 83/83 (10 suites); new pure-logic suites for the derivation, frozen decoding, holdings classification, fiat estimate
- `yarn lint`: 0 errors (68 pre-existing `no-explicit-any` warnings, none in touched files); `tsc` clean
- Not yet checked on device: DC shows `frozen: true`; a visible non-Helium token appears in the sheet and review step; hidden token raises the warning; "+ 1 unpriced" suffix

## Known issues to decide on before merge

- USDC/USDT are visible defaults with no price key, so most wallets will now show "+ 1 unpriced" (per spec, but the most common case).
- Hotspot-fetch error still blocks the whole flow.



