### PR TITLE
Keystone: fix replayed signature, bad-QR crash, add message signing, bump SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@helium/voter-stake-registry-sdk": "0.12.2",
     "@helium/wallet-link": "^5.0.4",
     "@jup-ag/api": "6.0.6",
-    "@keystonehq/keystone-sdk": "0.11.7",
+    "@keystonehq/keystone-sdk": "0.12.3",
     "@ledgerhq/hw-app-solana": "7.5.2",
     "@ledgerhq/react-native-hid": "6.32.9",
     "@ledgerhq/react-native-hw-transport-ble": "6.35.2",
@@ -280,7 +280,7 @@
     "@helium/voter-stake-registry-sdk": "0.12.2",
     "@helium/modular-governance-hooks": "0.1.6",
     "@helium/onboarding": "^5.0.4",
-    "@keystonehq/bc-ur-registry": "0.7.1"
+    "@keystonehq/bc-ur-registry": "0.8.0"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/src/features/keystone/KeystoneModal.tsx
+++ b/src/features/keystone/KeystoneModal.tsx
@@ -84,16 +84,22 @@ const KeystoneModal = forwardRef(
         const keystonePromise = new Promise<Buffer | undefined>((resolve) => {
           promiseResolve = resolve
         })
-        // listen the keystone signature event
-        eventEmitter.on(`keystoneSignature_${requestId}`, (signature) => {
+        // Listeners are removed on settle so repeated sign requests in one
+        // session do not stack handlers.
+        const onSignature = (signature: string) => {
+          settle(Buffer.from(signature, 'hex'))
+        }
+        const onClose = () => {
+          settle(Buffer.from([]))
+        }
+        const settle = (value: Buffer) => {
+          eventEmitter.off(`keystoneSignature_${requestId}`, onSignature)
+          eventEmitter.off('closeKeystoneSignatureModal', onClose)
           bottomSheetModalRef.current?.dismiss()
-          promiseResolve(Buffer.from(signature, 'hex'))
-        })
-
-        eventEmitter.on('closeKeystoneSignatureModal', () => {
-          bottomSheetModalRef.current?.dismiss()
-          promiseResolve(Buffer.from([]))
-        })
+          promiseResolve(value)
+        }
+        eventEmitter.on(`keystoneSignature_${requestId}`, onSignature)
+        eventEmitter.on('closeKeystoneSignatureModal', onClose)
         return keystonePromise
       },
       [

--- a/src/features/keystone/KeystoneModal.tsx
+++ b/src/features/keystone/KeystoneModal.tsx
@@ -35,7 +35,6 @@ export type KeystoneModalRef = {
   }) => Promise<Buffer | undefined>
 }
 
-let promiseResolve: (value: Buffer | PromiseLike<Buffer>) => void
 const KeystoneModal = forwardRef(
   (
     { children }: { children: ReactNode },
@@ -46,6 +45,7 @@ const KeystoneModal = forwardRef(
     const { currentAccount } = useAccountStorage()
     const { backgroundStyle } = useOpacity('surfaceSecondary', 1)
     const bottomSheetModalRef = useRef<BottomSheetModal>(null)
+    const settleRef = useRef<((value: Buffer) => void) | undefined>(undefined)
     const [solSignRequest, setSolSignRequest] =
       useState<KeystoneSolSignRequest>()
     const showKeystoneModal = useCallback(
@@ -81,6 +81,7 @@ const KeystoneModal = forwardRef(
             origin: 'Helium',
           })
         }
+        let promiseResolve: (value: Buffer) => void = () => {}
         const keystonePromise = new Promise<Buffer | undefined>((resolve) => {
           promiseResolve = resolve
         })
@@ -95,9 +96,11 @@ const KeystoneModal = forwardRef(
         const settle = (value: Buffer) => {
           eventEmitter.off(`keystoneSignature_${requestId}`, onSignature)
           eventEmitter.off('closeKeystoneSignatureModal', onClose)
+          settleRef.current = undefined
           bottomSheetModalRef.current?.dismiss()
           promiseResolve(value)
         }
+        settleRef.current = settle
         eventEmitter.on(`keystoneSignature_${requestId}`, onSignature)
         eventEmitter.on('closeKeystoneSignatureModal', onClose)
         return keystonePromise
@@ -123,6 +126,12 @@ const KeystoneModal = forwardRef(
     const { colors } = useTheme()
     const sheetHandleStyle = useMemo(() => ({ padding: m }), [m])
     const { handleDismiss } = useBackHandler(bottomSheetModalRef)
+    // Backdrop tap, swipe down and back button dismiss the sheet without an
+    // event, so the pending sign request has to be settled here.
+    const handleSheetDismiss = useCallback(() => {
+      settleRef.current?.(Buffer.from([]))
+      handleDismiss()
+    }, [handleDismiss])
 
     const handleIndicatorStyle = useMemo(() => {
       return {
@@ -140,7 +149,7 @@ const KeystoneModal = forwardRef(
             backdropComponent={renderBackdrop}
             snapPoints={snapPoints}
             handleStyle={sheetHandleStyle}
-            onDismiss={handleDismiss}
+            onDismiss={handleSheetDismiss}
             handleIndicatorStyle={handleIndicatorStyle}
           >
             <BottomSheetView style={{ flex: 1 }}>

--- a/src/features/keystone/SignTx/SignTxModal.tsx
+++ b/src/features/keystone/SignTx/SignTxModal.tsx
@@ -5,15 +5,11 @@ import Box from '@components/Box'
 import Text from '@components/Text'
 import ButtonPressable from '@components/ButtonPressable'
 import { useTranslation } from 'react-i18next'
-import KeystoneSDK, {
-  SolSignature,
-  UR,
-  URDecoder,
-} from '@keystonehq/keystone-sdk'
+import KeystoneSDK, { SolSignature } from '@keystonehq/keystone-sdk'
 import { AnimatedQrCode } from '@components/StaticQrCode'
 import useAlert from '@hooks/useAlert'
 import { BarcodeScanningResult, Camera, CameraView } from 'expo-camera'
-import { Linking, Platform, StyleSheet } from 'react-native'
+import { Alert, Linking, Platform, StyleSheet } from 'react-native'
 import ProgressBar from '@components/ProgressBar'
 import { useAsync } from 'react-async-hook'
 import EventEmitter from 'events'
@@ -22,6 +18,7 @@ import CloseButton from '@components/CloseButton'
 import { useHitSlop } from '@theme/themeHooks'
 import { CameraScannerLayout } from '../../../components/CameraScannerLayout'
 import { KeystoneSolSignRequest } from '../types/keystoneSolanaTxType'
+import { createSignatureScanner } from './signatureScanner'
 
 type Props = {
   progress: number
@@ -105,7 +102,10 @@ const ScanTxQrcodeScreen = ({
 }) => {
   const { t } = useTranslation()
   const keystoneSDK = useMemo(() => new KeystoneSDK(), [])
-  const decoder = useMemo(() => new URDecoder(), [])
+  const scanner = useMemo(
+    () => createSignatureScanner(keystoneSDK),
+    [keystoneSDK],
+  )
   const solSignRequestUr = useMemo(() => {
     if (!solSignRequest?.requestId) return undefined
     return keystoneSDK.sol.generateSignRequest(solSignRequest)
@@ -117,14 +117,27 @@ const ScanTxQrcodeScreen = ({
     setOpenQrCodeScanner(true)
   }
 
+  // A half-scanned signature from a previous request must not carry over
+  useEffect(() => {
+    scanner.reset()
+    setSignature(null)
+    setProgress(0)
+  }, [scanner, solSignRequest?.requestId])
+
   const handleBarCodeScanned = (qrString: string) => {
-    decoder.receivePart(qrString.toLowerCase())
-    setProgress(Number((decoder.getProgress() * 100).toFixed(0)))
-    if (decoder.isComplete()) {
-      const ur = decoder.resultUR()
-      const buffer = Buffer.from(ur.cbor.toString('hex'), 'hex')
+    const result = scanner.receive(qrString, solSignRequest.requestId)
+    if (result.status === 'progress') {
+      setProgress(result.progress)
+    } else if (result.status === 'complete') {
       setProgress(100)
-      setSignature(keystoneSDK.sol.parseSignature(new UR(buffer, ur.type)))
+      setSignature(result.signature)
+    } else {
+      setOpenQrCodeScanner(false)
+      setProgress(0)
+      Alert.alert(
+        t('keystone.connectKeystoneStart.unexpectedQrCodeTitle'),
+        t('keystone.connectKeystoneStart.unexpectedQrCodeContent'),
+      )
     }
   }
   useEffect(() => {

--- a/src/features/keystone/SignTx/SignTxModal.tsx
+++ b/src/features/keystone/SignTx/SignTxModal.tsx
@@ -113,7 +113,9 @@ const ScanTxQrcodeScreen = ({
   const [openQrCodeScanner, setOpenQrCodeScanner] = useState(false)
   const [progress, setProgress] = useState<number>(0)
   const [signature, setSignature] = useState<SolSignature | null>(null)
+  const [isUnexpectedQrCode, setIsUnexpectedQrCode] = useState(false)
   const handleGetSignature = () => {
+    setIsUnexpectedQrCode(false)
     setOpenQrCodeScanner(true)
   }
 
@@ -122,6 +124,7 @@ const ScanTxQrcodeScreen = ({
     scanner.reset()
     setSignature(null)
     setProgress(0)
+    setIsUnexpectedQrCode(false)
   }, [scanner, solSignRequest?.requestId])
 
   const handleBarCodeScanned = (qrString: string) => {
@@ -134,12 +137,19 @@ const ScanTxQrcodeScreen = ({
     } else {
       setOpenQrCodeScanner(false)
       setProgress(0)
+      setIsUnexpectedQrCode(true)
+    }
+  }
+  // The camera keeps scanning until it unmounts, so alert once per bad scan
+  useEffect(() => {
+    if (isUnexpectedQrCode) {
       Alert.alert(
         t('keystone.connectKeystoneStart.unexpectedQrCodeTitle'),
         t('keystone.connectKeystoneStart.unexpectedQrCodeContent'),
       )
     }
-  }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isUnexpectedQrCode])
   useEffect(() => {
     if (progress === 100 && signature) {
       setOpenQrCodeScanner(false)

--- a/src/features/keystone/SignTx/signatureScanner.ts
+++ b/src/features/keystone/SignTx/signatureScanner.ts
@@ -1,0 +1,47 @@
+import KeystoneSDK, {
+  SolSignature,
+  UR,
+  URDecoder,
+} from '@keystonehq/keystone-sdk'
+
+export type ScanResult =
+  | { status: 'progress'; progress: number }
+  | { status: 'complete'; signature: SolSignature }
+  | { status: 'error'; error: unknown }
+
+// A completed URDecoder ignores further parts and keeps returning its first
+// result, so the decoder must be replaced after every completion or failure.
+// Otherwise a second sign request in the same app session replays the first
+// signature.
+export const createSignatureScanner = (sdk: KeystoneSDK) => {
+  let decoder = new URDecoder()
+  const reset = () => {
+    decoder = new URDecoder()
+  }
+  const receive = (qrString: string, expectedRequestId: string): ScanResult => {
+    try {
+      decoder.receivePart(qrString.toLowerCase())
+      if (!decoder.isComplete()) {
+        return {
+          status: 'progress',
+          progress: Math.round(decoder.getProgress() * 100),
+        }
+      }
+      const ur = decoder.resultUR()
+      reset()
+      const signature = sdk.sol.parseSignature(
+        new UR(Buffer.from(ur.cbor.toString('hex'), 'hex'), ur.type),
+      )
+      if (signature.requestId !== expectedRequestId) {
+        throw new Error(
+          `Signature is for request ${signature.requestId}, expected ${expectedRequestId}`,
+        )
+      }
+      return { status: 'complete', signature }
+    } catch (error) {
+      reset()
+      return { status: 'error', error }
+    }
+  }
+  return { receive, reset }
+}

--- a/src/features/keystone/SignTx/signatureScanner.ts
+++ b/src/features/keystone/SignTx/signatureScanner.ts
@@ -21,6 +21,9 @@ export const createSignatureScanner = (sdk: KeystoneSDK) => {
   const receive = (qrString: string, expectedRequestId: string): ScanResult => {
     try {
       decoder.receivePart(qrString.toLowerCase())
+      if (decoder.isError()) {
+        throw new Error(decoder.resultError())
+      }
       if (!decoder.isComplete()) {
         return {
           status: 'progress',
@@ -29,9 +32,7 @@ export const createSignatureScanner = (sdk: KeystoneSDK) => {
       }
       const ur = decoder.resultUR()
       reset()
-      const signature = sdk.sol.parseSignature(
-        new UR(Buffer.from(ur.cbor.toString('hex'), 'hex'), ur.type),
-      )
+      const signature = sdk.sol.parseSignature(new UR(ur.cbor, ur.type))
       if (signature.requestId !== expectedRequestId) {
         throw new Error(
           `Signature is for request ${signature.requestId}, expected ${expectedRequestId}`,

--- a/src/features/keystone/__tests__/signRequest.test.ts
+++ b/src/features/keystone/__tests__/signRequest.test.ts
@@ -120,6 +120,16 @@ describe('Keystone sol-sign-request', () => {
     expect(uuid.stringify(decoded.getRequestId() as Buffer)).toBe(req.requestId)
   })
 
+  test('message sign request round-trips with SignType.Message', () => {
+    const msgBytes = Buffer.from('Helium governance vote', 'utf8')
+    const req = buildRequest(msgBytes, KeystoneSolanaSDK.DataType.Message)
+    const ur = sdk.sol.generateSignRequest(req)
+    const { result } = roundTripThroughFrames(ur)
+    const decoded = SolSignRequest.fromCBOR(result.cbor)
+    expect(decoded.getSignData().equals(msgBytes)).toBe(true)
+    expect(decoded.getSignType()).toBe(SignType.Message)
+  })
+
   test('DataType.Transaction is SignType.Transaction (1)', () => {
     expect(KeystoneSolanaSDK.DataType.Transaction).toBe(1)
     expect(KeystoneSolanaSDK.DataType.Message).toBe(2)

--- a/src/features/keystone/__tests__/signRequest.test.ts
+++ b/src/features/keystone/__tests__/signRequest.test.ts
@@ -9,7 +9,6 @@ import KeystoneSDK, {
   URDecoder,
 } from '@keystonehq/keystone-sdk'
 import { uuid } from '@keystonehq/keystone-sdk/dist/utils'
-import { UREncoder } from '@ngraveio/bc-ur'
 // Transitive deps of @keystonehq/keystone-sdk; used here to decode what the
 // device would receive.
 /* eslint-disable import/no-extraneous-dependencies */
@@ -28,9 +27,8 @@ import {
   VersionedTransaction,
 } from '@solana/web3.js'
 import { KeystoneSolSignRequest } from '../types/keystoneSolanaTxType'
+import { urToFrames } from './urFrames'
 
-// Same value as src/components/StaticQrCode.tsx
-const MAX_FRAGMENT_CAPACITY = 200
 const PATH = "m/44'/501'/0'/0'"
 const XFP = '12345678'
 
@@ -82,11 +80,7 @@ const buildRequest = (
 
 // Mirrors AnimatedQrCode (encode) + SignTxModal.handleBarCodeScanned (decode)
 const roundTripThroughFrames = (ur: UR) => {
-  const encoder = new UREncoder(ur, MAX_FRAGMENT_CAPACITY)
-  const frames: string[] = []
-  for (let i = 0; i < encoder.fragmentsLength; i += 1) {
-    frames.push(encoder.nextPart())
-  }
+  const frames = urToFrames(ur)
   const decoder = new URDecoder()
   frames.forEach((f) => decoder.receivePart(f.toLowerCase()))
   expect(decoder.isComplete()).toBe(true)
@@ -156,9 +150,7 @@ describe('Keystone sol-signature', () => {
     // Device emits frames; app scans them
     const { result } = roundTripThroughFrames(new UR(sigUr.cbor, sigUr.type))
 
-    // Exact code from SignTxModal.handleBarCodeScanned
-    const buffer = Buffer.from(result.cbor.toString('hex'), 'hex')
-    const parsed = sdk.sol.parseSignature(new UR(buffer, result.type))
+    const parsed = sdk.sol.parseSignature(new UR(result.cbor, result.type))
 
     expect(parsed.requestId).toBe(requestId)
     expect(parsed.signature).toBe(sig.toString('hex'))

--- a/src/features/keystone/__tests__/signRequest.test.ts
+++ b/src/features/keystone/__tests__/signRequest.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Device-less verification of the Keystone Solana sign path used by
+ * SignTxModal: generateSignRequest -> multi-part UR frames -> decode back to
+ * the same tx bytes, and parseSignature on a synthetic sol-signature UR.
+ */
+import KeystoneSDK, {
+  KeystoneSolanaSDK,
+  UR,
+  URDecoder,
+} from '@keystonehq/keystone-sdk'
+import { uuid } from '@keystonehq/keystone-sdk/dist/utils'
+import { UREncoder } from '@ngraveio/bc-ur'
+// Transitive deps of @keystonehq/keystone-sdk; used here to decode what the
+// device would receive.
+/* eslint-disable import/no-extraneous-dependencies */
+import {
+  SolSignRequest,
+  SolSignature,
+  SignType,
+} from '@keystonehq/bc-ur-registry-sol'
+/* eslint-enable import/no-extraneous-dependencies */
+import {
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js'
+import { KeystoneSolSignRequest } from '../types/keystoneSolanaTxType'
+
+// Same value as src/components/StaticQrCode.tsx
+const MAX_FRAGMENT_CAPACITY = 200
+const PATH = "m/44'/501'/0'/0'"
+const XFP = '12345678'
+
+const from = Keypair.generate()
+const to = Keypair.generate().publicKey
+const blockhash = new PublicKey(Keypair.generate().publicKey).toBase58()
+
+const legacyTxBytes = () => {
+  const tx = new Transaction({
+    feePayer: from.publicKey,
+    recentBlockhash: blockhash,
+  }).add(
+    SystemProgram.transfer({
+      fromPubkey: from.publicKey,
+      toPubkey: to,
+      lamports: 1,
+    }),
+  )
+  return tx.serialize({ requireAllSignatures: false })
+}
+
+const versionedTxBytes = () => {
+  const msg = new TransactionMessage({
+    payerKey: from.publicKey,
+    recentBlockhash: blockhash,
+    instructions: [
+      SystemProgram.transfer({
+        fromPubkey: from.publicKey,
+        toPubkey: to,
+        lamports: 1,
+      }),
+    ],
+  }).compileToV0Message()
+  return Buffer.from(new VersionedTransaction(msg).serialize())
+}
+
+// Mirrors KeystoneModal.showKeystoneModal
+const buildRequest = (
+  transaction: Buffer,
+  dataType = KeystoneSolanaSDK.DataType.Transaction,
+): KeystoneSolSignRequest => ({
+  requestId: uuid.v4(),
+  signData: transaction.toString('hex'),
+  dataType,
+  path: PATH,
+  xfp: XFP,
+  origin: 'Helium',
+})
+
+// Mirrors AnimatedQrCode (encode) + SignTxModal.handleBarCodeScanned (decode)
+const roundTripThroughFrames = (ur: UR) => {
+  const encoder = new UREncoder(ur, MAX_FRAGMENT_CAPACITY)
+  const frames: string[] = []
+  for (let i = 0; i < encoder.fragmentsLength; i += 1) {
+    frames.push(encoder.nextPart())
+  }
+  const decoder = new URDecoder()
+  frames.forEach((f) => decoder.receivePart(f.toLowerCase()))
+  expect(decoder.isComplete()).toBe(true)
+  const result = decoder.resultUR()
+  return { frames, result }
+}
+
+describe('Keystone sol-sign-request', () => {
+  const sdk = new KeystoneSDK()
+
+  test.each([
+    ['legacy', legacyTxBytes],
+    ['versioned', versionedTxBytes],
+  ])('%s tx round-trips through multi-part UR frames', (_name, mk) => {
+    const txBytes = mk()
+    const req = buildRequest(txBytes)
+    const ur = sdk.sol.generateSignRequest(req)
+
+    expect(ur.type).toBe('sol-sign-request')
+
+    const { frames, result } = roundTripThroughFrames(ur)
+    expect(frames.length).toBeGreaterThan(1)
+    expect(result.type).toBe('sol-sign-request')
+
+    const decoded = SolSignRequest.fromCBOR(result.cbor)
+    expect(decoded.getSignData().equals(txBytes)).toBe(true)
+    expect(decoded.getSignType()).toBe(SignType.Transaction)
+    // CryptoKeypath drops the "m/" prefix; this is the registry's format
+    expect(decoded.getDerivationPath()).toBe(PATH.replace(/^m\//, ''))
+    expect(decoded.getOrigin()).toBe('Helium')
+    expect(uuid.stringify(decoded.getRequestId() as Buffer)).toBe(req.requestId)
+  })
+
+  test('DataType.Transaction is SignType.Transaction (1)', () => {
+    expect(KeystoneSolanaSDK.DataType.Transaction).toBe(1)
+    expect(KeystoneSolanaSDK.DataType.Message).toBe(2)
+  })
+
+  test('generateSignRequest throws on an empty requestId (guard in SignTxModal)', () => {
+    const req = { ...buildRequest(legacyTxBytes()), requestId: '' }
+    expect(() => sdk.sol.generateSignRequest(req)).toThrow()
+  })
+})
+
+describe('Keystone sol-signature', () => {
+  const sdk = new KeystoneSDK()
+
+  test('parseSignature accepts a synthetic sol-signature UR via the scanner path', () => {
+    const requestId = uuid.v4()
+    const sig = Buffer.alloc(64, 7)
+    const sigUr = new SolSignature(
+      sig,
+      Buffer.from(uuid.parse(requestId) as Uint8Array),
+    ).toUR()
+    expect(sigUr.type).toBe('sol-signature')
+
+    // Device emits frames; app scans them
+    const { result } = roundTripThroughFrames(new UR(sigUr.cbor, sigUr.type))
+
+    // Exact code from SignTxModal.handleBarCodeScanned
+    const buffer = Buffer.from(result.cbor.toString('hex'), 'hex')
+    const parsed = sdk.sol.parseSignature(new UR(buffer, result.type))
+
+    expect(parsed.requestId).toBe(requestId)
+    expect(parsed.signature).toBe(sig.toString('hex'))
+    expect(Buffer.from(parsed.signature, 'hex').equals(sig)).toBe(true)
+  })
+
+  test('parseSignature rejects a UR of the wrong type', () => {
+    const ur = sdk.sol.generateSignRequest(buildRequest(legacyTxBytes()))
+    expect(() => sdk.sol.parseSignature(ur)).toThrow('type not match')
+  })
+})
+
+describe('Buffer global at bc-ur-registry load time', () => {
+  // Requires the registry (and cbor-sync) fresh, then the sol registry on top
+  // of it, and returns a thunk that encodes a minimal sign request.
+  const loadAndBuild = () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require, import/no-extraneous-dependencies
+    const sol = require('@keystonehq/bc-ur-registry-sol')
+    return () =>
+      sol.SolSignRequest.constructSOLRequest(
+        Buffer.from('0102', 'hex'),
+        PATH,
+        XFP,
+        sol.SignType.Transaction,
+        '0c8c2c7e-3b3a-4c8f-9a8c-2f1c3e4d5a6b',
+      ).toUR()
+  }
+
+  test('present: encodes', () => {
+    jest.isolateModules(() => {
+      expect(loadAndBuild()().type).toBe('sol-sign-request')
+    })
+  })
+
+  test('absent at load, present at call: "Unsupported output format: undefined"', () => {
+    const saved = global.Buffer
+    try {
+      jest.isolateModules(() => {
+        // @ts-expect-error simulate a runtime without the Buffer global
+        delete global.Buffer
+        // cbor-sync registers its Buffer writer only if Buffer is a function
+        // when the module body runs.
+        // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require, import/no-extraneous-dependencies
+        require('@keystonehq/bc-ur-registry')
+        global.Buffer = saved
+        expect(loadAndBuild()).toThrow('Unsupported output format: undefined')
+      })
+    } finally {
+      global.Buffer = saved
+    }
+  })
+
+  test('keystone-sdk itself cannot even load without Buffer', () => {
+    const saved = global.Buffer
+    try {
+      jest.isolateModules(() => {
+        // @ts-expect-error simulate a runtime without the Buffer global
+        delete global.Buffer
+        // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+        expect(() => require('@keystonehq/keystone-sdk')).toThrow(
+          'Buffer is not defined',
+        )
+      })
+    } finally {
+      global.Buffer = saved
+    }
+  })
+})

--- a/src/features/keystone/__tests__/signatureScanner.test.ts
+++ b/src/features/keystone/__tests__/signatureScanner.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The scanner that SignTxModal feeds camera frames into. Uses the real
+ * bc-ur decoder and keystone-sdk; no mocks.
+ */
+import KeystoneSDK, { UR } from '@keystonehq/keystone-sdk'
+import { uuid } from '@keystonehq/keystone-sdk/dist/utils'
+import { UREncoder } from '@ngraveio/bc-ur'
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { SolSignature } from '@keystonehq/bc-ur-registry-sol'
+import { createSignatureScanner } from '../SignTx/signatureScanner'
+
+const MAX_FRAGMENT_CAPACITY = 200
+
+const framesFor = (
+  requestId: string,
+  fill: number,
+  fragmentCapacity = MAX_FRAGMENT_CAPACITY,
+) => {
+  const ur = new SolSignature(
+    Buffer.alloc(64, fill),
+    Buffer.from(uuid.parse(requestId) as Uint8Array),
+  ).toUR()
+  const encoder = new UREncoder(new UR(ur.cbor, ur.type), fragmentCapacity)
+  const frames: string[] = []
+  for (let i = 0; i < encoder.fragmentsLength; i += 1) {
+    frames.push(encoder.nextPart())
+  }
+  return frames
+}
+
+const scanAll = (
+  scanner: ReturnType<typeof createSignatureScanner>,
+  requestId: string,
+  frames: string[],
+) => frames.map((f) => scanner.receive(f, requestId))
+
+describe('createSignatureScanner', () => {
+  const scanner = createSignatureScanner(new KeystoneSDK())
+
+  test('decodes a complete signature for the expected request', () => {
+    const requestId = uuid.v4()
+    const results = scanAll(scanner, requestId, framesFor(requestId, 1))
+    expect(results[results.length - 1]).toEqual({
+      status: 'complete',
+      signature: expect.objectContaining({
+        requestId,
+        signature: Buffer.alloc(64, 1).toString('hex'),
+      }),
+    })
+  })
+
+  test('a second request gets its own signature, not a replay of the first', () => {
+    const first = uuid.v4()
+    const second = uuid.v4()
+    scanAll(scanner, first, framesFor(first, 1))
+
+    const results = scanAll(scanner, second, framesFor(second, 2))
+    expect(results[results.length - 1]).toEqual({
+      status: 'complete',
+      signature: expect.objectContaining({
+        requestId: second,
+        signature: Buffer.alloc(64, 2).toString('hex'),
+      }),
+    })
+  })
+
+  test('a signature for a different request is rejected', () => {
+    const expected = uuid.v4()
+    const other = uuid.v4()
+    const results = scanAll(scanner, expected, framesFor(other, 3))
+    expect(results[results.length - 1].status).toBe('error')
+  })
+
+  test('a non-UR QR string reports an error instead of throwing', () => {
+    expect(() =>
+      scanner.receive('https://example.com', uuid.v4()),
+    ).not.toThrow()
+    expect(scanner.receive('https://example.com', uuid.v4()).status).toBe(
+      'error',
+    )
+  })
+
+  test('a sol-sign-request UR (wrong type) reports an error', () => {
+    const requestId = uuid.v4()
+    const sdk = new KeystoneSDK()
+    const ur = sdk.sol.generateSignRequest({
+      requestId,
+      signData: '0102',
+      dataType: 1,
+      path: "m/44'/501'/0'/0'",
+      xfp: '12345678',
+      origin: 'Helium',
+    })
+    const encoder = new UREncoder(ur, 10_000)
+    expect(scanner.receive(encoder.nextPart(), requestId).status).toBe('error')
+  })
+
+  test('reports progress before completion and stays scannable after an error', () => {
+    const requestId = uuid.v4()
+    // A sol-signature fits one 200-byte frame; force multi-part
+    const frames = framesFor(requestId, 4, 30)
+    expect(frames.length).toBeGreaterThan(1)
+    expect(scanner.receive('garbage', requestId).status).toBe('error')
+    expect(scanner.receive(frames[0], requestId)).toEqual({
+      status: 'progress',
+      progress: expect.any(Number),
+    })
+    const results = scanAll(scanner, requestId, frames.slice(1))
+    expect(results[results.length - 1].status).toBe('complete')
+  })
+})

--- a/src/features/keystone/__tests__/signatureScanner.test.ts
+++ b/src/features/keystone/__tests__/signatureScanner.test.ts
@@ -8,8 +8,7 @@ import { UREncoder } from '@ngraveio/bc-ur'
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { SolSignature } from '@keystonehq/bc-ur-registry-sol'
 import { createSignatureScanner } from '../SignTx/signatureScanner'
-
-const MAX_FRAGMENT_CAPACITY = 200
+import { MAX_FRAGMENT_CAPACITY, urToFrames } from './urFrames'
 
 const framesFor = (
   requestId: string,
@@ -20,12 +19,7 @@ const framesFor = (
     Buffer.alloc(64, fill),
     Buffer.from(uuid.parse(requestId) as Uint8Array),
   ).toUR()
-  const encoder = new UREncoder(new UR(ur.cbor, ur.type), fragmentCapacity)
-  const frames: string[] = []
-  for (let i = 0; i < encoder.fragmentsLength; i += 1) {
-    frames.push(encoder.nextPart())
-  }
-  return frames
+  return urToFrames(new UR(ur.cbor, ur.type), fragmentCapacity)
 }
 
 const scanAll = (

--- a/src/features/keystone/__tests__/urFrames.ts
+++ b/src/features/keystone/__tests__/urFrames.ts
@@ -1,0 +1,18 @@
+// jest's testMatch is **/__tests__/**/*.test.ts, so this file is not a suite
+import { UR, UREncoder } from '@ngraveio/bc-ur'
+
+// Same value as src/components/StaticQrCode.tsx
+export const MAX_FRAGMENT_CAPACITY = 200
+
+// Mirrors AnimatedQrCode: the animated frames a device scans or emits
+export const urToFrames = (
+  ur: UR,
+  fragmentCapacity = MAX_FRAGMENT_CAPACITY,
+) => {
+  const encoder = new UREncoder(ur, fragmentCapacity)
+  const frames: string[] = []
+  for (let i = 0; i < encoder.fragmentsLength; i += 1) {
+    frames.push(encoder.nextPart())
+  }
+  return frames
+}

--- a/src/solana/SolanaProvider.tsx
+++ b/src/solana/SolanaProvider.tsx
@@ -162,6 +162,16 @@ const useSolanaHook = () => {
         return Buffer.from(signedMessage)
       }
 
+      if (currentAccount?.keystoneDevice) {
+        const signature = await keystoneModalRef.current?.showKeystoneModal({
+          message: msg,
+        })
+        if (!signature || signature.length === 0) {
+          throw new Error('Message not signed')
+        }
+        return signature
+      }
+
       const signedMessage = await ledgerModalRef?.current?.showLedgerModal({
         message: msg,
       })

--- a/src/solana/SolanaProvider.tsx
+++ b/src/solana/SolanaProvider.tsx
@@ -151,7 +151,8 @@ const useSolanaHook = () => {
         (!currentAccount?.ledgerDevice?.id ||
           !currentAccount?.ledgerDevice?.type ||
           !currentAccount?.accountIndex) &&
-        secureAcct?.secretKey
+        secureAcct?.secretKey &&
+        !currentAccount?.keystoneDevice
       ) {
         const signer = {
           publicKey: currentAccount?.solanaAddress,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3924,23 +3924,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@keystonehq/bc-ur-registry@npm:0.7.1":
-  version: 0.7.1
-  resolution: "@keystonehq/bc-ur-registry@npm:0.7.1"
+"@keystonehq/bc-ur-registry@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@keystonehq/bc-ur-registry@npm:0.8.0"
   dependencies:
     "@ngraveio/bc-ur": "npm:^1.1.5"
     bs58check: "npm:^2.1.2"
     tslib: "npm:^2.3.0"
-  checksum: 10/6dd2a86ef83d385af93c1064097669baf06965cb051a123731109699eefc512ddf446a622c29e2afd3e559a5e5f98f1e7373e66179e7e027363111b450bc28f7
+  checksum: 10/efe46c007cb0e5646dd916e5aa60bab391e47cdf2f0cde7744b9c39e326f4c123d5242b0012feccb8ec97c8de5c6773c38f796ec907c888e6426bf8f2ddc9086
   languageName: node
   linkType: hard
 
-"@keystonehq/keystone-sdk@npm:0.11.7":
-  version: 0.11.7
-  resolution: "@keystonehq/keystone-sdk@npm:0.11.7"
+"@keystonehq/keystone-sdk@npm:0.12.3":
+  version: 0.12.3
+  resolution: "@keystonehq/keystone-sdk@npm:0.12.3"
   dependencies:
     "@bufbuild/protobuf": "npm:^1.2.0"
-    "@keystonehq/bc-ur-registry": "npm:^0.7.1"
+    "@keystonehq/bc-ur-registry": "npm:0.8.0"
     "@keystonehq/bc-ur-registry-aptos": "npm:^0.6.3"
     "@keystonehq/bc-ur-registry-arweave": "npm:^0.5.3"
     "@keystonehq/bc-ur-registry-avalanche": "npm:^0.0.4"
@@ -3964,7 +3964,7 @@ __metadata:
     pako: "npm:^2.1.0"
     ripple-binary-codec: "npm:^1.4.3"
     uuid: "npm:^9.0.0"
-  checksum: 10/4dde87196a7f69df58414c2f3804383c84e9ad9f2883326f4613a3b6a07a360d361a06d936c2cd9f70d6eaf2c6e1cd1e2253ca5faf4dae485d5cd144e34e6f3b
+  checksum: 10/71aba652dadf56a2e4fbbb2938641c274a0e08198ce5ef04b54a367503cfabb66c2470e5fcc86fd7537862c773a4616f30b73a5fe35b4983957733230e1df1ff
   languageName: node
   linkType: hard
 
@@ -13059,7 +13059,7 @@ __metadata:
     "@helium/voter-stake-registry-sdk": "npm:0.12.2"
     "@helium/wallet-link": "npm:^5.0.4"
     "@jup-ag/api": "npm:6.0.6"
-    "@keystonehq/keystone-sdk": "npm:0.11.7"
+    "@keystonehq/keystone-sdk": "npm:0.12.3"
     "@ledgerhq/hw-app-solana": "npm:7.5.2"
     "@ledgerhq/hw-transport-mocker": "npm:6.29.8"
     "@ledgerhq/react-native-hid": "npm:6.32.9"


### PR DESCRIPTION
## Why

Two users reported Keystone signing broken ~6 months apart; nobody on the team has a device. This PR verifies the encoding path without one and fixes the defects the review found.

## Changes

- **Signature scanner resets per request** (`SignTx/signatureScanner.ts`). `SignTxModal` is mounted once and kept a single `URDecoder`; bc-ur ignores parts after completion, so the **second signing in a session replayed the first signature** and failed on submit.
- **Reject signatures for a different `requestId`.**
- **Non-UR / wrong-type QR** now shows the "unexpected QR" alert instead of throwing uncaught from the camera callback.
- **`KeystoneModal` removes its event listeners** once a request settles.
- **Message signing**: `signMsg` routes Keystone accounts to `KeystoneModal` (`DataType.Message`) instead of falling through to the Ledger modal.
- **SDK bump**: `@keystonehq/keystone-sdk` 0.11.7 → 0.12.3; `bc-ur-registry` resolution 0.7.1 → 0.8.0 (0.12.3 hard-pins 0.8.0). Solana path is byte-identical between versions.

## Verification (device-less)

16 Jest tests on the real bc-ur + keystone-sdk, no mocks: legacy/versioned/message sign requests round-trip through 200-byte UR frames; synthetic `sol-signature` parses; second-request replay is caught; bad QR does not throw. `yarn lint` clean for touched files.

Not verified on a physical Keystone. Ask affected users to retest on the build containing this.

## Deferred

`setTimeout(1000)` before `present()`; `KeystoneAccountAssignScreen` avatar decodes pubkey without `'hex'`.
