### PR TITLE
Show veHNT positions on Migrate to World review screen

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -12,6 +12,9 @@
       "distribution": "internal"
     },
     "production": {
+      "android": {
+        "resourceClass": "large"
+      },
       "ios": {
         "image": "macos-sequoia-15.6-xcode-26.2"
       }

--- a/src/features/migration/MigrateToWorld.tsx
+++ b/src/features/migration/MigrateToWorld.tsx
@@ -1,6 +1,7 @@
 import SafeAreaBox from '@components/SafeAreaBox'
 import { useCurrentWallet } from '@hooks/useCurrentWallet'
 import { useNavigation } from '@react-navigation/native'
+import { useGovernance } from '@storage/GovernanceProvider'
 import React, {
   memo,
   useCallback,
@@ -74,6 +75,15 @@ const MigrateToWorld = () => {
     step !== 'intro' && step !== 'connect' && step !== 'login'
   const assets = useMigrationAssets(assetsNeeded ? sourceWallet : undefined)
   const { run, progress } = useMigrationExecutor(persist)
+  // veHNT positions aren't selectable: the migrate API re-enumerates them
+  // on-chain and moves them with everything else. Surface the count on the
+  // review screen so the user isn't surprised. Proxied-to-me positions belong
+  // to someone else and don't move.
+  const { positions } = useGovernance()
+  const positionCount = useMemo(
+    () => positions?.filter((p) => !p.isProxiedToMe).length ?? 0,
+    [positions],
+  )
 
   const [selection, setSelection] = useState<AssetSelection>()
   const [error, setError] = useState<string>()
@@ -325,6 +335,7 @@ const MigrateToWorld = () => {
             sourceWallet={sourceWallet || ''}
             destinationWallet={destinationWallet || ''}
             hotspotCount={selection?.hotspotKeys.size ?? 0}
+            positionCount={positionCount}
             tokenLines={tokenLines}
             error={error}
             onBack={() => setStep('select')}

--- a/src/features/migration/components/ReviewStep.tsx
+++ b/src/features/migration/components/ReviewStep.tsx
@@ -86,6 +86,7 @@ const ReviewStep: FC<{
   sourceWallet: string
   destinationWallet: string
   hotspotCount: number
+  positionCount: number
   tokenLines: ReviewTokenLine[]
   error?: string
   onBack: () => void
@@ -94,6 +95,7 @@ const ReviewStep: FC<{
   sourceWallet,
   destinationWallet,
   hotspotCount,
+  positionCount,
   tokenLines,
   error,
   onBack,
@@ -137,6 +139,18 @@ const ReviewStep: FC<{
             {tokenLines.map((line) => (
               <TokenLine key={line.mint} line={line} />
             ))}
+            {positionCount > 0 && (
+              <Box>
+                <Divider />
+                <Line
+                  label={t('migrateToWorld.confirm.positions')}
+                  value={String(positionCount)}
+                />
+                <Text variant="body3" color="worldSecondaryInk">
+                  {t('migrateToWorld.confirm.positionsNote')}
+                </Text>
+              </Box>
+            )}
           </Card>
 
           <Card>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1659,6 +1659,9 @@ export default {
       destination: 'To',
       fees: 'Fees',
       free: 'Free',
+      positions: 'veHNT positions',
+      positionsNote:
+        'Your locked HNT positions move to your new wallet automatically.',
       button: 'Confirm & migrate',
     },
     migrating: {


### PR DESCRIPTION
## Summary
- Migrate to World review (confirm) screen now lists the wallet's owned veHNT positions with a count and a note that they move automatically. The migrate API re-enumerates positions on-chain, so the client never selects them; this makes that visible before the user confirms.
- Proxied-to-me positions are excluded from the count. The row is hidden when the count is zero.
- Also carries the earlier EAS large-worker change for Android store builds (eas.json).

## Test plan
- [ ] `yarn lint` passes
- [ ] Open Settings → Migrate to Helium World with a wallet holding veHNT positions, proceed to the review step, and confirm the "veHNT positions" row and note render under the token lines
- [ ] Repeat with a wallet holding no positions and confirm the row is absent
