### PR TITLE
Fix Ledger BLE signing flow and device scan

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,10 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
 
     <uses-feature
         android:name="android.hardware.bluetooth_le"

--- a/ios/HeliumWallet.xcodeproj/project.pbxproj
+++ b/ios/HeliumWallet.xcodeproj/project.pbxproj
@@ -868,7 +868,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.15.10;
+				MARKETING_VERSION = 2.15.11;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -906,7 +906,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.15.10;
+				MARKETING_VERSION = 2.15.11;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1093,7 +1093,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.15.10;
+				MARKETING_VERSION = 2.15.11;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
@@ -1138,7 +1138,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.15.10;
+				MARKETING_VERSION = 2.15.11;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.helium.wallet.app.OneSignalNotificationServiceExtension;
@@ -1186,7 +1186,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.15.10;
+				MARKETING_VERSION = 2.15.11;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
@@ -1235,7 +1235,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.15.10;
+				MARKETING_VERSION = 2.15.11;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.helium.wallet.app.HeliumWalletWidget;

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@keystonehq/keystone-sdk": "0.12.3",
     "@ledgerhq/errors": "6.24.0",
     "@ledgerhq/hw-app-solana": "7.5.2",
+    "@ledgerhq/hw-transport": "6.31.9",
     "@ledgerhq/react-native-hid": "6.32.9",
     "@ledgerhq/react-native-hw-transport-ble": "6.35.2",
     "@ledgerhq/types-devices": "6.25.3",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@helium/wallet-link": "^5.0.4",
     "@jup-ag/api": "6.0.6",
     "@keystonehq/keystone-sdk": "0.12.3",
+    "@ledgerhq/errors": "6.24.0",
     "@ledgerhq/hw-app-solana": "7.5.2",
     "@ledgerhq/react-native-hid": "6.32.9",
     "@ledgerhq/react-native-hw-transport-ble": "6.35.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helium-wallet",
-  "version": "2.15.10",
+  "version": "2.15.11",
   "private": true,
   "scripts": {
     "eas-build-post-install": "./scripts/eas-build-setup.sh",

--- a/src/features/ledger/DeviceScan.tsx
+++ b/src/features/ledger/DeviceScan.tsx
@@ -2,7 +2,12 @@ import React, { useCallback, useState, useRef, useMemo, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FlatList, LayoutChangeEvent } from 'react-native'
 import { Device } from 'react-native-ble-plx'
-import { RouteProp, useNavigation, useRoute } from '@react-navigation/native'
+import {
+  RouteProp,
+  useFocusEffect,
+  useNavigation,
+  useRoute,
+} from '@react-navigation/native'
 import CarotRight from '@assets/images/carot-right.svg'
 import LedgerCircle from '@assets/images/ledger-circle.svg'
 import Ledger from '@assets/images/ledger.svg'
@@ -36,15 +41,36 @@ const DeviceScan = () => {
   const bottomSheetModalRef = useRef<BottomSheetModal>(null)
   const [contentHeight, setContentHeight] = useState(0)
   const { handleDismiss, setIsShowing } = useBackHandler(bottomSheetModalRef)
-  const { refreshing, error, devices, setError, reload } = useLedgerDeviceScan()
+  const {
+    refreshing,
+    error,
+    errorKind,
+    devices,
+    setError,
+    reload,
+    startScan,
+    stopScan,
+  } = useLedgerDeviceScan()
 
   useEffect(() => {
-    if (!route.params?.error) {
+    const routeError = route.params?.error
+    if (!routeError) {
       return
     }
 
-    setError(route.params.error)
-  }, [route, setError])
+    setError(routeError)
+    // Consume the param so the sheet does not re-present on later re-renders
+    navigation.setParams({ error: undefined })
+  }, [navigation, route.params?.error, setError])
+
+  // Scan only while this screen is focused, so no scan runs during the
+  // connect on DeviceShow
+  useFocusEffect(
+    useCallback(() => {
+      startScan()
+      return stopScan
+    }, [startScan, stopScan]),
+  )
 
   const snapPoints = useMemo(() => {
     let maxHeight: number | string = '90%'
@@ -84,6 +110,7 @@ const DeviceScan = () => {
 
   const onSelectDevice = useCallback(
     (device: Device) => () => {
+      stopScan()
       navigation.navigate('DeviceShow', {
         ledgerDevice: {
           id: device.id,
@@ -92,7 +119,7 @@ const DeviceScan = () => {
         },
       })
     },
-    [navigation],
+    [navigation, stopScan],
   )
 
   const handleContentLayout = useCallback((e: LayoutChangeEvent) => {
@@ -188,6 +215,7 @@ const DeviceScan = () => {
           <LedgerConnectSteps
             onLayout={handleContentLayout}
             onRetry={handleRetry}
+            errorKind={errorKind}
           />
         </BottomSheetScrollView>
       </BottomSheetModal>

--- a/src/features/ledger/DeviceScan.tsx
+++ b/src/features/ledger/DeviceScan.tsx
@@ -47,7 +47,6 @@ const DeviceScan = () => {
     errorKind,
     devices,
     setError,
-    reload,
     startScan,
     stopScan,
   } = useLedgerDeviceScan()
@@ -96,8 +95,8 @@ const DeviceScan = () => {
   const clearError = useCallback(() => {
     handleDismiss()
     setError(undefined)
-    reload()
-  }, [handleDismiss, reload, setError])
+    startScan()
+  }, [handleDismiss, startScan, setError])
 
   useEffect(() => {
     if (!error) return
@@ -198,7 +197,7 @@ const DeviceScan = () => {
             data={devices}
             renderItem={renderItem}
             keyExtractor={keyExtractor}
-            onRefresh={reload}
+            onRefresh={startScan}
             refreshing={refreshing}
           />
         </Box>

--- a/src/features/ledger/LedgerConnectSteps.tsx
+++ b/src/features/ledger/LedgerConnectSteps.tsx
@@ -7,10 +7,12 @@ import Box from '@components/Box'
 import Text from '@components/Text'
 import TouchableOpacityBox from '@components/TouchableOpacityBox'
 import { useColors } from '@theme/themeHooks'
+import type { ScanErrorKind } from '@hooks/useLedgerDeviceScan'
 
 interface LedgerConnectStepsProps {
   onLayout?: (event: LayoutChangeEvent) => void
   onRetry: () => void
+  errorKind?: ScanErrorKind
 }
 
 interface StepItemProps {
@@ -39,7 +41,11 @@ const StepItem = memo(({ step, index, iconColor }: StepItemProps) => (
   </Box>
 ))
 
-const LedgerConnectSteps = ({ onLayout, onRetry }: LedgerConnectStepsProps) => {
+const LedgerConnectSteps = ({
+  onLayout,
+  onRetry,
+  errorKind,
+}: LedgerConnectStepsProps) => {
   const { t } = useTranslation()
   const { primaryText } = useColors()
   const steps = useMemo<string[]>(
@@ -47,13 +53,20 @@ const LedgerConnectSteps = ({ onLayout, onRetry }: LedgerConnectStepsProps) => {
     [t],
   )
 
+  // Bluetooth-off and permission errors have their own copy and no steps
+  const hasSpecificCopy =
+    errorKind === 'bluetoothOff' || errorKind === 'permission'
   const translations = useMemo(
     () => ({
-      title: t('ledger.connectError.title'),
-      subtitle: t('ledger.connectError.subtitle'),
+      title: hasSpecificCopy
+        ? t(`ledger.connectError.${errorKind}.title`)
+        : t('ledger.connectError.title'),
+      subtitle: hasSpecificCopy
+        ? t(`ledger.connectError.${errorKind}.subtitle`)
+        : t('ledger.connectError.subtitle'),
       tryAgain: t('generic.tryAgain'),
     }),
-    [t],
+    [errorKind, hasSpecificCopy, t],
   )
 
   const handleRetry = useCallback(() => {
@@ -90,14 +103,15 @@ const LedgerConnectSteps = ({ onLayout, onRetry }: LedgerConnectStepsProps) => {
       </Text>
 
       <Box marginVertical="s">
-        {steps.map((step, index) => (
-          <StepItem
-            key={step}
-            step={step}
-            index={index}
-            iconColor={primaryText}
-          />
-        ))}
+        {!hasSpecificCopy &&
+          steps.map((step, index) => (
+            <StepItem
+              key={step}
+              step={step}
+              index={index}
+              iconColor={primaryText}
+            />
+          ))}
       </Box>
 
       <TouchableOpacityBox

--- a/src/features/ledger/LedgerModal.tsx
+++ b/src/features/ledger/LedgerModal.tsx
@@ -10,7 +10,7 @@ import {
   BottomSheetScrollView,
 } from '@gorhom/bottom-sheet'
 import useBackHandler from '@hooks/useBackHandler'
-import useLedger from '@hooks/useLedger'
+import useLedger, { LedgerTransport } from '@hooks/useLedger'
 import { DeviceModelId } from '@ledgerhq/types-devices'
 import { BoxProps } from '@shopify/restyle'
 import { useAccountStorage } from '@storage/AccountStorageProvider'
@@ -52,6 +52,7 @@ type SigningSession = {
 
 type LedgerModalState =
   | 'loading'
+  | 'scanning'
   | 'openApp'
   | 'sign'
   | 'enterPinCode'
@@ -75,7 +76,7 @@ const LedgerModal = forwardRef(
   ({ children }: Props, ref: Ref<LedgerModalRef | undefined>) => {
     useImperativeHandle(ref, () => ({ showLedgerModal }))
 
-    const { currentAccount } = useAccountStorage()
+    const { currentAccount, upsertAccount } = useAccountStorage()
     const bottomSheetModalRef = useRef<BottomSheetModal>(null)
     const { backgroundStyle } = useOpacity('surfaceSecondary', 1)
     const { handleDismiss, setIsShowing } = useBackHandler(bottomSheetModalRef)
@@ -83,6 +84,8 @@ const LedgerModal = forwardRef(
     const { t } = useTranslation()
     const {
       getTransport,
+      findBleDevice,
+      openBleDevice,
       openSolanaApp,
       reconnectAfterAppOpen,
       waitForSolanaApp,
@@ -114,7 +117,27 @@ const LedgerModal = forwardRef(
           bottomSheetModalRef.current?.present()
           setIsShowing(true)
 
-          let transport = await getTransport(deviceId, deviceType)
+          let transport: LedgerTransport | undefined
+          try {
+            transport = await getTransport(deviceId, deviceType)
+          } catch (error) {
+            if (
+              deviceType !== 'bluetooth' ||
+              classifyLedgerError(error) !== 'transport'
+            ) {
+              throw error
+            }
+            // The stored BLE id may be from another phone or a forgotten
+            // pairing. Find the device by name and pair it by descriptor.
+            setLedgerModalState('scanning')
+            const found = await findBleDevice(currentAccount.ledgerDevice.name)
+            if (!found) throw error
+            transport = await openBleDevice(found)
+            await upsertAccount({
+              ...currentAccount,
+              ledgerDevice: { ...currentAccount.ledgerDevice, id: found.id },
+            })
+          }
           if (!transport) {
             setLedgerModalState('error')
             return
@@ -191,8 +214,11 @@ const LedgerModal = forwardRef(
       },
       [
         currentAccount,
+        upsertAccount,
         setIsShowing,
         getTransport,
+        findBleDevice,
+        openBleDevice,
         openSolanaApp,
         reconnectAfterAppOpen,
         waitForSolanaApp,
@@ -313,6 +339,14 @@ const LedgerModal = forwardRef(
       switch (ledgerModalState) {
         case 'loading':
           return null
+        case 'scanning':
+          return (
+            <Text variant="h4Medium" color="primaryText">
+              {t('ledger.lookingForDevice', {
+                device: currentAccount?.ledgerDevice?.name,
+              })}
+            </Text>
+          )
         case 'openApp':
           return (
             <Text variant="h4Medium" color="primaryText">
@@ -427,35 +461,37 @@ const LedgerModal = forwardRef(
                 {ledgerModalState !== 'loading' &&
                   ledgerModalState !== 'error' && (
                     <>
-                      {ledgerModalState !== 'failed' && (
-                        <Box
-                          alignSelf="stretch"
-                          alignItems="center"
-                          justifyContent="center"
-                          minHeight={120}
-                        >
-                          <Animation
-                            source={getDeviceAnimation({
-                              device: {
-                                deviceId:
-                                  currentAccount?.ledgerDevice?.id ?? '',
-                                deviceName:
-                                  currentAccount?.ledgerDevice?.name ?? '',
-                                modelId: deviceModelId,
-                                wired:
-                                  currentAccount?.ledgerDevice?.type === 'usb',
-                              },
-                              key: ledgerModalState,
-                              theme: 'dark',
-                            })}
-                            style={
-                              deviceModelId === DeviceModelId.stax
-                                ? { height: 210 }
-                                : { height: 120 }
-                            }
-                          />
-                        </Box>
-                      )}
+                      {ledgerModalState !== 'failed' &&
+                        ledgerModalState !== 'scanning' && (
+                          <Box
+                            alignSelf="stretch"
+                            alignItems="center"
+                            justifyContent="center"
+                            minHeight={120}
+                          >
+                            <Animation
+                              source={getDeviceAnimation({
+                                device: {
+                                  deviceId:
+                                    currentAccount?.ledgerDevice?.id ?? '',
+                                  deviceName:
+                                    currentAccount?.ledgerDevice?.name ?? '',
+                                  modelId: deviceModelId,
+                                  wired:
+                                    currentAccount?.ledgerDevice?.type ===
+                                    'usb',
+                                },
+                                key: ledgerModalState,
+                                theme: 'dark',
+                              })}
+                              style={
+                                deviceModelId === DeviceModelId.stax
+                                  ? { height: 210 }
+                                  : { height: 120 }
+                              }
+                            />
+                          </Box>
+                        )}
                       <Box>{LedgerMessage()}</Box>
                     </>
                   )}

--- a/src/features/ledger/LedgerModal.tsx
+++ b/src/features/ledger/LedgerModal.tsx
@@ -88,6 +88,10 @@ const LedgerModal = forwardRef(
       waitForSolanaApp,
     } = useLedger()
     const sessionRef = useRef<SigningSession | undefined>(undefined)
+    // Session whose settle triggered our own dismiss(). onDismiss fires after
+    // the close animation, by which time the caller may have started the next
+    // session, which must not be rejected.
+    const settledSessionRef = useRef<SigningSession | undefined>(undefined)
     const [failureMessage, setFailureMessage] = useState<string>()
 
     const [ledgerModalState, setLedgerModalState] =
@@ -128,14 +132,15 @@ const LedgerModal = forwardRef(
             appAlreadyOpen = true
           }
 
-          if (!appAlreadyOpen) {
+          if (appAlreadyOpen) {
+            await waitForSolanaApp(transport)
+          } else {
             transport = await reconnectAfterAppOpen(
               transport,
               deviceId,
               deviceType,
             )
           }
-          await waitForSolanaApp(transport)
 
           setLedgerModalState('sign')
 
@@ -157,12 +162,14 @@ const LedgerModal = forwardRef(
               )
 
           session.resolve(signature)
+          settledSessionRef.current = session
           bottomSheetModalRef.current?.dismiss()
         } catch (error) {
           console.error(error)
           switch (classifyLedgerError(error)) {
             case 'userRejected':
               session.reject(error as Error)
+              settledSessionRef.current = session
               bottomSheetModalRef.current?.dismiss()
               break
             case 'locked':
@@ -295,7 +302,11 @@ const LedgerModal = forwardRef(
     // back, and our own dismiss() after settling.
     const onDismiss = useCallback(() => {
       handleDismiss()
-      sessionRef.current?.reject(new Error('User closed modal'))
+      const settled = settledSessionRef.current
+      settledSessionRef.current = undefined
+      if (sessionRef.current !== settled) {
+        sessionRef.current?.reject(new Error('User closed modal'))
+      }
     }, [handleDismiss])
 
     const LedgerMessage = useCallback(() => {

--- a/src/features/ledger/LedgerModal.tsx
+++ b/src/features/ledger/LedgerModal.tsx
@@ -19,6 +19,7 @@ import { useColors, useOpacity } from '@theme/themeHooks'
 import SafeAreaBox from '@components/SafeAreaBox'
 import { Edge } from 'react-native-safe-area-context'
 import {
+  classifyLedgerError,
   signLedgerMessage,
   signLedgerTransaction,
   getDerivationTypeForSigning,
@@ -39,8 +40,24 @@ import Animation from './Animation'
 import LedgerConnectSteps from './LedgerConnectSteps'
 import { getDeviceAnimation } from './getDeviceAnimation'
 
-let promiseResolve: (value: Buffer | PromiseLike<Buffer>) => void
-let promiseReject: (reason?: Error) => void
+// One signing session per showLedgerModal call. Retries reuse the same
+// session so the caller's promise always settles exactly once.
+type SigningSession = {
+  transaction?: Buffer
+  message?: Buffer
+  settled: boolean
+  resolve: (value: Buffer) => void
+  reject: (reason: Error) => void
+}
+
+type LedgerModalState =
+  | 'loading'
+  | 'openApp'
+  | 'sign'
+  | 'enterPinCode'
+  | 'error'
+  | 'enableBlindSign'
+  | 'failed'
 
 export type LedgerModalRef = {
   showLedgerModal: ({
@@ -61,131 +78,108 @@ const LedgerModal = forwardRef(
     const { currentAccount } = useAccountStorage()
     const bottomSheetModalRef = useRef<BottomSheetModal>(null)
     const { backgroundStyle } = useOpacity('surfaceSecondary', 1)
-    const { setIsShowing } = useBackHandler(bottomSheetModalRef)
+    const { handleDismiss, setIsShowing } = useBackHandler(bottomSheetModalRef)
     const { secondaryText } = useColors()
     const { t } = useTranslation()
-    const { getTransport, openSolanaApp, waitForSolanaApp } = useLedger()
-    const [transactionBuffer, setTransactionBuffer] = useState<Buffer>()
-    const [messageBuffer, setMessageBuffer] = useState<Buffer>()
+    const {
+      getTransport,
+      openSolanaApp,
+      reconnectAfterAppOpen,
+      waitForSolanaApp,
+    } = useLedger()
+    const sessionRef = useRef<SigningSession | undefined>(undefined)
+    const [failureMessage, setFailureMessage] = useState<string>()
 
-    const [ledgerModalState, setLedgerModalState] = useState<
-      | 'loading'
-      | 'openApp'
-      | 'sign'
-      | 'enterPinCode'
-      | 'error'
-      | 'enableBlindSign'
-    >('loading')
+    const [ledgerModalState, setLedgerModalState] =
+      useState<LedgerModalState>('loading')
 
-    const openAppAndSign = useCallback(
-      async ({
-        transactionBuffer: tBuffer,
-        messageBuffer: mBuffer,
-      }: {
-        transactionBuffer?: Buffer
-        messageBuffer?: Buffer
-      }) => {
+    const runSigningSession = useCallback(
+      async (session: SigningSession) => {
         if (
-          (!tBuffer && !mBuffer) ||
           !currentAccount?.ledgerDevice?.id ||
           !currentAccount?.ledgerDevice?.type ||
           currentAccount?.accountIndex === undefined
         ) {
+          session.reject(new Error('Ledger account is not configured'))
           return
         }
-
-        const p = new Promise<Buffer>((resolve, reject) => {
-          promiseResolve = resolve
-          promiseReject = reject
-        })
+        const { id: deviceId, type: deviceType } = currentAccount.ledgerDevice
 
         try {
           setLedgerModalState('loading')
           bottomSheetModalRef.current?.present()
           setIsShowing(true)
 
-          let nextTransport = await getTransport(
-            currentAccount.ledgerDevice.id,
-            currentAccount.ledgerDevice.type,
-          )
-
-          if (!nextTransport) {
+          let transport = await getTransport(deviceId, deviceType)
+          if (!transport) {
             setLedgerModalState('error')
-            // eslint-disable-next-line @typescript-eslint/return-await
-            return p
+            return
           }
 
+          setLedgerModalState('openApp')
+          let appAlreadyOpen = false
           try {
-            setLedgerModalState('openApp')
-            await openSolanaApp(nextTransport)
-            await waitForSolanaApp(nextTransport)
+            await openSolanaApp(transport)
           } catch (error) {
-            const ledgerError = error as Error
-            switch (ledgerError.message) {
-              case 'Ledger device: Locked device (0x5515)':
-                setLedgerModalState('enterPinCode')
-                return p
-              // Happens when solana app already open
-              case 'Ledger device: INS_NOT_SUPPORTED (0x6d00)':
-                break
-              default:
-                setLedgerModalState('error')
-                break
+            if (classifyLedgerError(error) !== 'appNotOpen') {
+              throw error
             }
+            // 0x6d00 / 0x6e00 here means the Solana app answered: it is open
+            appAlreadyOpen = true
           }
+
+          if (!appAlreadyOpen) {
+            transport = await reconnectAfterAppOpen(
+              transport,
+              deviceId,
+              deviceType,
+            )
+          }
+          await waitForSolanaApp(transport)
 
           setLedgerModalState('sign')
 
-          nextTransport = await getTransport(
-            currentAccount.ledgerDevice.id,
-            currentAccount.ledgerDevice.type,
+          const derivationType = getDerivationTypeForSigning(
+            currentAccount.derivationPath,
           )
+          const signature = session.transaction
+            ? await signLedgerTransaction(
+                transport,
+                currentAccount.accountIndex,
+                session.transaction,
+                derivationType,
+              )
+            : await signLedgerMessage(
+                transport,
+                currentAccount.accountIndex,
+                session.message as Buffer,
+                derivationType,
+              )
 
-          if (!nextTransport) {
-            setLedgerModalState('error')
-            // eslint-disable-next-line @typescript-eslint/return-await
-            return p
-          }
-
-          let signature
-
-          if (tBuffer) {
-            signature = await signLedgerTransaction(
-              nextTransport,
-              currentAccount.accountIndex,
-              tBuffer,
-              getDerivationTypeForSigning(currentAccount?.derivationPath),
-            )
-          } else if (mBuffer) {
-            signature = await signLedgerMessage(
-              nextTransport,
-              currentAccount?.accountIndex,
-              mBuffer,
-              getDerivationTypeForSigning(currentAccount?.derivationPath),
-            )
-          }
-
+          session.resolve(signature)
           bottomSheetModalRef.current?.dismiss()
-          return signature
         } catch (error) {
           console.error(error)
-          const ledgerError = error as Error
-          switch (ledgerError.message) {
-            case 'Missing a parameter. Try enabling blind signature in the app':
+          switch (classifyLedgerError(error)) {
+            case 'userRejected':
+              session.reject(error as Error)
+              bottomSheetModalRef.current?.dismiss()
+              break
+            case 'locked':
+              setLedgerModalState('enterPinCode')
+              break
+            case 'blindSign':
               setLedgerModalState('enableBlindSign')
               break
-            case 'User rejected transaction':
-              // Reject promise immediately and dismiss modal
-              if (promiseReject) {
-                promiseReject(ledgerError)
-              }
-              bottomSheetModalRef.current?.dismiss()
-              return
-            default:
+            case 'transport':
               setLedgerModalState('error')
+              break
+            default:
+              setFailureMessage(
+                error instanceof Error ? error.message : String(error),
+              )
+              setLedgerModalState('failed')
           }
-
-          return p
         }
       },
       [
@@ -193,30 +187,46 @@ const LedgerModal = forwardRef(
         setIsShowing,
         getTransport,
         openSolanaApp,
+        reconnectAfterAppOpen,
         waitForSolanaApp,
       ],
     )
 
     const showLedgerModal = useCallback(
-      async ({
+      ({
         transaction,
         message,
       }: {
         transaction?: Buffer
         message?: Buffer
       }) => {
-        if (transaction) {
-          setTransactionBuffer(transaction)
+        if (!transaction && !message) {
+          return Promise.resolve(undefined)
         }
-        if (message) {
-          setMessageBuffer(message)
-        }
-        return openAppAndSign({
-          transactionBuffer: transaction,
-          messageBuffer: message,
+
+        const promise = new Promise<Buffer>((resolve, reject) => {
+          const session: SigningSession = {
+            transaction,
+            message,
+            settled: false,
+            resolve: (value) => {
+              if (session.settled) return
+              session.settled = true
+              resolve(value)
+            },
+            reject: (reason) => {
+              if (session.settled) return
+              session.settled = true
+              reject(reason)
+            },
+          }
+          sessionRef.current = session
+          runSigningSession(session)
         })
+
+        return promise
       },
-      [openAppAndSign],
+      [runSigningSession],
     )
 
     const renderBackdrop = useCallback(
@@ -245,7 +255,14 @@ const LedgerModal = forwardRef(
         return model
       }
 
-      if (currentAccount?.ledgerDevice?.name.toLowerCase().includes('nano s')) {
+      // 'nano sp' must be checked before 'nano s', which it also contains
+      if (
+        currentAccount?.ledgerDevice?.name.toLowerCase().includes('nano sp')
+      ) {
+        model = DeviceModelId.nanoSP
+      } else if (
+        currentAccount?.ledgerDevice?.name.toLowerCase().includes('nano s')
+      ) {
         model = DeviceModelId.nanoS
       } else if (
         currentAccount?.ledgerDevice?.name.toLowerCase().includes('nano x')
@@ -259,38 +276,27 @@ const LedgerModal = forwardRef(
         currentAccount?.ledgerDevice?.name.toLowerCase().includes('blue')
       ) {
         model = DeviceModelId.blue
-      } else if (
-        currentAccount?.ledgerDevice?.name.toLowerCase().includes('nano sp')
-      ) {
-        model = DeviceModelId.nanoSP
       }
 
       return model
     }, [currentAccount?.ledgerDevice?.name])
 
-    const handleRetry = useCallback(async () => {
-      try {
-        const buffer = await openAppAndSign({
-          transactionBuffer,
-          messageBuffer,
-        })
+    const handleRetry = useCallback(() => {
+      const session = sessionRef.current
+      if (!session || session.settled) return
+      runSigningSession(session)
+    }, [runSigningSession])
 
-        if (buffer && promiseResolve) {
-          promiseResolve(buffer)
-        }
-      } catch (error) {
-        if (promiseReject) {
-          promiseReject(error as Error)
-        }
-      }
-    }, [openAppAndSign, transactionBuffer, messageBuffer])
-
-    const onDismiss = useCallback(() => {
-      if (promiseReject) {
-        promiseReject(new Error('User closed modal'))
-      }
+    const closeModal = useCallback(() => {
       bottomSheetModalRef.current?.dismiss()
     }, [])
+
+    // Fires for every dismissal: X button, swipe down, backdrop tap, Android
+    // back, and our own dismiss() after settling.
+    const onDismiss = useCallback(() => {
+      handleDismiss()
+      sessionRef.current?.reject(new Error('User closed modal'))
+    }, [handleDismiss])
 
     const LedgerMessage = useCallback(() => {
       switch (ledgerModalState) {
@@ -352,21 +358,38 @@ const LedgerModal = forwardRef(
               </TouchableOpacityBox>
             </Box>
           )
-        case 'error':
+        case 'failed':
           return (
             <Box>
               <Text variant="h4Medium" color="primaryText">
-                {t('ledger.transactionRejected')}
+                {t('ledger.signingFailed')}
               </Text>
               <Text variant="body1Medium" color="secondaryText" marginTop="s">
-                {t('ledger.transactionRejectedDescription')}
+                {failureMessage}
               </Text>
+              <TouchableOpacityBox
+                marginTop="s"
+                onPress={handleRetry}
+                backgroundColor="surface"
+                padding="l"
+                borderRadius="round"
+              >
+                <Text variant="subtitle1" textAlign="center">
+                  {t('generic.tryAgain')}
+                </Text>
+              </TouchableOpacityBox>
             </Box>
           )
         default:
           return null
       }
-    }, [currentAccount?.ledgerDevice?.name, handleRetry, ledgerModalState, t])
+    }, [
+      currentAccount?.ledgerDevice?.name,
+      failureMessage,
+      handleRetry,
+      ledgerModalState,
+      t,
+    ])
 
     return (
       <Box flex={1}>
@@ -378,11 +401,12 @@ const LedgerModal = forwardRef(
             backdropComponent={renderBackdrop}
             handleIndicatorStyle={handleIndicatorStyle}
             enableDynamicSizing
+            onDismiss={onDismiss}
           >
             <BottomSheetScrollView>
               <SafeAreaBox edges={safeEdges} paddingHorizontal="l">
                 <Box alignItems="flex-end" height={24} justifyContent="center">
-                  <CloseButton onPress={onDismiss} />
+                  <CloseButton onPress={closeModal} />
                 </Box>
                 {ledgerModalState === 'loading' && (
                   <Box alignItems="center" justifyContent="center" flex={1}>
@@ -392,32 +416,35 @@ const LedgerModal = forwardRef(
                 {ledgerModalState !== 'loading' &&
                   ledgerModalState !== 'error' && (
                     <>
-                      <Box
-                        alignSelf="stretch"
-                        alignItems="center"
-                        justifyContent="center"
-                        minHeight={120}
-                      >
-                        <Animation
-                          source={getDeviceAnimation({
-                            device: {
-                              deviceId: currentAccount?.ledgerDevice?.id ?? '',
-                              deviceName:
-                                currentAccount?.ledgerDevice?.name ?? '',
-                              modelId: deviceModelId,
-                              wired:
-                                currentAccount?.ledgerDevice?.type === 'usb',
-                            },
-                            key: ledgerModalState,
-                            theme: 'dark',
-                          })}
-                          style={
-                            deviceModelId === DeviceModelId.stax
-                              ? { height: 210 }
-                              : { height: 120 }
-                          }
-                        />
-                      </Box>
+                      {ledgerModalState !== 'failed' && (
+                        <Box
+                          alignSelf="stretch"
+                          alignItems="center"
+                          justifyContent="center"
+                          minHeight={120}
+                        >
+                          <Animation
+                            source={getDeviceAnimation({
+                              device: {
+                                deviceId:
+                                  currentAccount?.ledgerDevice?.id ?? '',
+                                deviceName:
+                                  currentAccount?.ledgerDevice?.name ?? '',
+                                modelId: deviceModelId,
+                                wired:
+                                  currentAccount?.ledgerDevice?.type === 'usb',
+                              },
+                              key: ledgerModalState,
+                              theme: 'dark',
+                            })}
+                            style={
+                              deviceModelId === DeviceModelId.stax
+                                ? { height: 210 }
+                                : { height: 120 }
+                            }
+                          />
+                        </Box>
+                      )}
                       <Box>{LedgerMessage()}</Box>
                     </>
                   )}

--- a/src/hooks/useLedger.ts
+++ b/src/hooks/useLedger.ts
@@ -148,7 +148,9 @@ const useLedger = () => {
   )
 
   // After the open-app APDU the device re-enumerates. Wait for the drop, then
-  // reopen the transport with retries and poll until the Solana app answers.
+  // reopen the transport with retries until the Solana app answers. The BLE
+  // cache may hand back the dying transport if the drop arrives late, so a
+  // disconnect from getAppConfiguration is retried here too.
   const reconnectAfterAppOpen = useCallback(
     async (
       previous: LedgerTransport,
@@ -157,27 +159,26 @@ const useLedger = () => {
     ): Promise<LedgerTransport> => {
       await waitForDisconnect(previous, DISCONNECT_WAIT_MS)
 
+      let lastError: unknown = new Error('Transport could not be created')
       for (let attempt = 1; attempt <= RECONNECT_ATTEMPTS; attempt += 1) {
         try {
           // eslint-disable-next-line no-await-in-loop
           const next = await getTransport(nextDeviceId, type)
-          if (next) return next
-          throw new Error('Transport could not be created')
+          if (!next) throw new Error('Transport could not be created')
+          // eslint-disable-next-line no-await-in-loop
+          await waitForSolanaApp(next)
+          return next
         } catch (error) {
-          if (
-            attempt === RECONNECT_ATTEMPTS ||
-            !isRetryableReconnectError(error)
-          ) {
-            throw error
-          }
+          if (!isRetryableReconnectError(error)) throw error
+          lastError = error
           // eslint-disable-next-line no-await-in-loop
           await delay(RECONNECT_DELAY_MS)
         }
       }
 
-      throw new Error('Transport could not be created')
+      throw lastError
     },
-    [getTransport],
+    [getTransport, waitForSolanaApp],
   )
 
   const createLedgerAccount = useCallback(

--- a/src/hooks/useLedger.ts
+++ b/src/hooks/useLedger.ts
@@ -1,6 +1,8 @@
 import AppSolana from '@ledgerhq/hw-app-solana'
+import type { DescriptorEvent } from '@ledgerhq/hw-transport'
 import TransportBLE from '@ledgerhq/react-native-hw-transport-ble'
 import TransportHID from '@ledgerhq/react-native-hid'
+import type { Device } from 'react-native-ble-plx'
 import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { bs58 } from '@coral-xyz/anchor/dist/cjs/utils/bytes'
@@ -33,9 +35,10 @@ export type LedgerAccount = {
 
 export const ManagerAppName = 'Solana'
 
-type LedgerTransport = TransportBLE | TransportHID
+export type LedgerTransport = TransportBLE | TransportHID
 
 export const BLE_CONNECT_TIMEOUT_MS = 10_000
+const BLE_FIND_TIMEOUT_MS = 15_000
 const RECONNECT_ATTEMPTS = 5
 const RECONNECT_DELAY_MS = 1_000
 const DISCONNECT_WAIT_MS = 1_500
@@ -145,6 +148,36 @@ const useLedger = () => {
       return newTransport
     },
     [closeUsbTransport],
+  )
+
+  // BLE ids are per phone. When the stored id no longer resolves, scan for a
+  // device advertising the stored name so it can be paired and opened by
+  // descriptor. Resolves undefined if nothing matches within the timeout.
+  const findBleDevice = useCallback(
+    (name: string): Promise<Device | undefined> =>
+      new Promise((resolve) => {
+        const done = (device?: Device) => {
+          clearTimeout(timer)
+          sub.unsubscribe()
+          resolve(device)
+        }
+        const timer = setTimeout(done, BLE_FIND_TIMEOUT_MS)
+        const sub = TransportBLE.listen({
+          next: (e: DescriptorEvent<Device>) => {
+            if (e.type !== 'add') return
+            const found = e.descriptor
+            if ((found.localName || found.name) === name) done(found)
+          },
+          error: () => done(),
+          complete: () => done(),
+        })
+      }),
+    [],
+  )
+
+  const openBleDevice = useCallback(
+    (device: Device) => TransportBLE.open(device, BLE_CONNECT_TIMEOUT_MS),
+    [],
   )
 
   // After the open-app APDU the device re-enumerates. Wait for the drop, then
@@ -519,6 +552,8 @@ const useLedger = () => {
 
   return {
     getTransport,
+    findBleDevice,
+    openBleDevice,
     reconnectAfterAppOpen,
     ledgerAccounts,
     updateLedgerAccounts,

--- a/src/hooks/useLedger.ts
+++ b/src/hooks/useLedger.ts
@@ -1,7 +1,7 @@
 import AppSolana from '@ledgerhq/hw-app-solana'
 import TransportBLE from '@ledgerhq/react-native-hw-transport-ble'
 import TransportHID from '@ledgerhq/react-native-hid'
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { bs58 } from '@coral-xyz/anchor/dist/cjs/utils/bytes'
 import { solAddressToHelium } from '@utils/accountUtils'
@@ -12,8 +12,10 @@ import { HNT_MINT } from '@helium/spl-utils'
 import { useSolana } from '../solana/SolanaProvider'
 import { LedgerDevice } from '../storage/cloudStorage'
 import {
+  classifyLedgerError,
   getDerivationPath,
   getDerivationPathLabel,
+  isRetryableReconnectError,
   type DerivationType,
 } from '../utils/heliumLedger'
 
@@ -31,50 +33,69 @@ export type LedgerAccount = {
 
 export const ManagerAppName = 'Solana'
 
+type LedgerTransport = TransportBLE | TransportHID
+
+export const BLE_CONNECT_TIMEOUT_MS = 10_000
+const RECONNECT_ATTEMPTS = 5
+const RECONNECT_DELAY_MS = 1_000
+const DISCONNECT_WAIT_MS = 1_500
+const APP_READY_ATTEMPTS = 10
+const APP_READY_DELAY_MS = 200
+
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
+// Resolves on the transport's disconnect event, or after ms if it never comes.
+const waitForDisconnect = (transport: LedgerTransport, ms: number) =>
+  new Promise<void>((resolve) => {
+    const done = () => {
+      clearTimeout(timer)
+      transport.off('disconnect', done)
+      resolve()
+    }
+    const timer = setTimeout(done, ms)
+    transport.on('disconnect', done)
+  })
+
 const useLedger = () => {
-  const [transport, setTransport] = useState<{
-    transport: TransportBLE | TransportHID
-    deviceId: string
-  }>()
+  // BLE transports are cached by the library and evicted on disconnect, so
+  // TransportBLE.open is safe to call on every use. HID has no such cache, so
+  // keep the open USB transport here until it disconnects.
+  const usbTransport = useRef<
+    { transport: TransportHID; deviceId: string } | undefined
+  >(undefined)
   const [ledgerAccounts, setLedgerAccounts] = useState<LedgerAccount[]>([])
   const [ledgerAccountsLoading, setLedgerAccountsLoading] = useState(false)
   const { t } = useTranslation()
   const { anchorProvider, connection } = useSolana()
 
-  const openSolanaApp = useCallback(
-    async (trans: TransportBLE | TransportHID) => {
-      await trans.send(
-        0xe0,
-        0xd8,
-        0x00,
-        0x00,
-        Buffer.from(ManagerAppName, 'utf8'),
-      )
-    },
-    [],
-  )
+  const openSolanaApp = useCallback(async (trans: LedgerTransport) => {
+    await trans.send(
+      0xe0,
+      0xd8,
+      0x00,
+      0x00,
+      Buffer.from(ManagerAppName, 'utf8'),
+    )
+  }, [])
 
   const waitForSolanaApp = useCallback(
-    async (trans: TransportBLE | TransportHID, maxAttempts = 10) => {
+    async (trans: LedgerTransport, maxAttempts = APP_READY_ATTEMPTS) => {
       const solana = new AppSolana(trans)
 
       for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
         try {
-          // Try to get app configuration - this will succeed when Solana app is ready
+          // eslint-disable-next-line no-await-in-loop
           await solana.getAppConfiguration()
-          return // App is ready
+          return
         } catch (error) {
-          const errorStr = error?.toString() || ''
-
-          // If app is not open yet, wait and retry
-          if (errorStr.includes('0x6e00') || errorStr.includes('0x6d00')) {
-            await new Promise((resolve) => setTimeout(resolve, 200))
-            // eslint-disable-next-line no-continue
-            continue
+          if (classifyLedgerError(error) !== 'appNotOpen') {
+            throw error
           }
-
-          // For other errors, throw immediately
-          throw error
+          // eslint-disable-next-line no-await-in-loop
+          await delay(APP_READY_DELAY_MS)
         }
       }
 
@@ -83,47 +104,80 @@ const useLedger = () => {
     [],
   )
 
+  const closeUsbTransport = useCallback(() => {
+    const { current } = usbTransport
+    usbTransport.current = undefined
+    current?.transport.close().catch(() => {})
+  }, [])
+
   const getTransport = useCallback(
-    async (nextDeviceId: string, type: 'usb' | 'bluetooth') => {
-      // If we have the same device, reuse the existing transport
-      if (transport?.deviceId === nextDeviceId && transport.transport) {
-        return transport.transport
+    async (
+      nextDeviceId: string,
+      type: 'usb' | 'bluetooth',
+    ): Promise<LedgerTransport | undefined> => {
+      if (type === 'bluetooth') {
+        return TransportBLE.open(nextDeviceId, BLE_CONNECT_TIMEOUT_MS)
       }
 
-      // Close existing transport if switching devices
-      if (transport && transport.deviceId !== nextDeviceId) {
-        try {
-          transport.transport.close()
-        } catch (error) {
-          // Ignore close errors
-        }
-        setTransport(undefined)
+      const cached = usbTransport.current
+      if (cached?.deviceId === nextDeviceId) {
+        return cached.transport
+      }
+      if (cached) {
+        closeUsbTransport()
       }
 
-      let newTransport: TransportBLE | TransportHID | null = null
-      if (type === 'usb') {
-        await TransportHID.create()
-        const devices = await TransportHID.list()
-        const device = devices.find(
-          (d) => d.deviceId === parseInt(nextDeviceId, 10),
-        )
-        if (!device) return
-        newTransport = await TransportHID.open(device)
-      } else {
-        newTransport = await TransportBLE.open(nextDeviceId)
-      }
-
+      await TransportHID.create()
+      const devices = await TransportHID.list()
+      const device = devices.find(
+        (d) => d.deviceId === parseInt(nextDeviceId, 10),
+      )
+      if (!device) return
+      const newTransport = await TransportHID.open(device)
       if (!newTransport) return
+
       newTransport.on('disconnect', () => {
-        // Intentionally for the sake of simplicity we use a transport local state
-        // and remove it on disconnect.
-        // A better way is to pass in the device.id and handle the connection internally.
-        setTransport(undefined)
+        if (usbTransport.current?.transport === newTransport) {
+          usbTransport.current = undefined
+        }
       })
-      setTransport({ transport: newTransport, deviceId: nextDeviceId })
+      usbTransport.current = { transport: newTransport, deviceId: nextDeviceId }
       return newTransport
     },
-    [transport],
+    [closeUsbTransport],
+  )
+
+  // After the open-app APDU the device re-enumerates. Wait for the drop, then
+  // reopen the transport with retries and poll until the Solana app answers.
+  const reconnectAfterAppOpen = useCallback(
+    async (
+      previous: LedgerTransport,
+      nextDeviceId: string,
+      type: 'usb' | 'bluetooth',
+    ): Promise<LedgerTransport> => {
+      await waitForDisconnect(previous, DISCONNECT_WAIT_MS)
+
+      for (let attempt = 1; attempt <= RECONNECT_ATTEMPTS; attempt += 1) {
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          const next = await getTransport(nextDeviceId, type)
+          if (next) return next
+          throw new Error('Transport could not be created')
+        } catch (error) {
+          if (
+            attempt === RECONNECT_ATTEMPTS ||
+            !isRetryableReconnectError(error)
+          ) {
+            throw error
+          }
+          // eslint-disable-next-line no-await-in-loop
+          await delay(RECONNECT_DELAY_MS)
+        }
+      }
+
+      throw new Error('Transport could not be created')
+    },
+    [getTransport],
   )
 
   const createLedgerAccount = useCallback(
@@ -446,7 +500,7 @@ const useLedger = () => {
         // Start checking all derivation paths for each account index
         await getLedgerAccounts(solana, mainAccounts)
       } catch (error) {
-        setTransport(undefined)
+        closeUsbTransport()
         throw error
       } finally {
         setLedgerAccountsLoading(false)
@@ -456,15 +510,15 @@ const useLedger = () => {
       createLedgerAccount,
       getLedgerAccounts,
       getTransport,
-      setTransport,
+      closeUsbTransport,
       ledgerAccountsLoading,
       checkBatchBalances,
     ],
   )
 
   return {
-    transport,
     getTransport,
+    reconnectAfterAppOpen,
     ledgerAccounts,
     updateLedgerAccounts,
     ledgerAccountsLoading,

--- a/src/hooks/useLedgerDeviceScan.tsx
+++ b/src/hooks/useLedgerDeviceScan.tsx
@@ -1,6 +1,7 @@
+import type { DescriptorEvent } from '@ledgerhq/hw-transport'
 import TransportBLE from '@ledgerhq/react-native-hw-transport-ble'
-import { useCallback, useState, useRef } from 'react'
-import { Observable, Subscription } from 'rxjs'
+import { BlePlxManager } from '@ledgerhq/react-native-hw-transport-ble/lib/BlePlxManager'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Platform } from 'react-native'
 import {
   check,
@@ -9,95 +10,100 @@ import {
   request,
   RESULTS,
 } from 'react-native-permissions'
-import { Device } from 'react-native-ble-plx'
-import { useAsync } from 'react-async-hook'
+import type {
+  Device,
+  Subscription as BleSubscription,
+} from 'react-native-ble-plx'
 import * as Logger from '../utils/logger'
 
-enum DeviceModelId {
-  blue = 'blue',
-  nanoS = 'nanoS',
-  nanoSP = 'nanoSP',
-  nanoX = 'nanoX',
-}
+export type ScanErrorKind = 'permission' | 'bluetoothOff' | 'unknown'
 
-type LedgerDetails = {
-  type: string
-  descriptor: Device
-  deviceModel: {
-    id: DeviceModelId
-    productName: string
-    productIdMM: number
-    legacyUsbProductId: number
-    usbOnly: boolean
-    memorySize: number
-    masks: number[]
-    // blockSize: number, // THIS FIELD IS DEPRECATED, use getBlockSize
-    getBlockSize: (firmwareVersion: string) => number
-    bluetoothSpec?: {
-      serviceUuid: string
-      writeUuid: string
-      writeCmdUuid: string
-      notifyUuid: string
-    }[]
-  }
-}
+type ScanError = { kind: ScanErrorKind; error: Error }
 
-type LedgerAvailable = {
-  available: boolean
-  type: string
-}
+type ScanSubscription = ReturnType<typeof TransportBLE.listen>
 
-const checkPermission = async () => {
-  let permissions: Permission[] = []
+// listen() never completes on its own, so stop scanning after this long.
+const SCAN_TIMEOUT_MS = 15_000
+
+const getBlePermissions = (): Permission[] => {
   if (Platform.OS === 'ios') {
-    permissions = [PERMISSIONS.IOS.BLUETOOTH]
-  } else if (Platform.OS === 'android') {
-    permissions = [
+    return [PERMISSIONS.IOS.BLUETOOTH]
+  }
+  if (Platform.OS !== 'android') {
+    return []
+  }
+  // BLUETOOTH_SCAN / BLUETOOTH_CONNECT exist from Android 12 (API 31).
+  // Older versions gate BLE scanning behind fine location instead.
+  if (Number(Platform.Version) >= 31) {
+    return [
       PERMISSIONS.ANDROID.BLUETOOTH_SCAN,
       PERMISSIONS.ANDROID.BLUETOOTH_CONNECT,
     ]
   }
+  return [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION]
+}
 
-  permissions.forEach(async (perm) => {
-    const result = await check(perm)
+const checkPermission = async (): Promise<boolean> => {
+  const permissions = getBlePermissions()
+
+  // Sequential on purpose: the OS shows one permission dialog at a time.
+  return permissions.reduce(async (previous, perm) => {
+    if (!(await previous)) return false
+
+    let result = await check(perm)
     if (result === RESULTS.DENIED) {
-      const requestResult = await request(perm)
-      if (requestResult !== RESULTS.GRANTED) {
-        return false
-      }
+      result = await request(perm)
     }
-  })
-
-  return true
+    return result !== RESULTS.DENIED && result !== RESULTS.BLOCKED
+  }, Promise.resolve(true))
 }
 
 const useDeviceScan = () => {
-  const sub = useRef<Subscription | null>(null)
+  const scanSub = useRef<ScanSubscription | undefined>(undefined)
+  const stateSub = useRef<BleSubscription | undefined>(undefined)
+  const scanTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const [refreshing, setRefreshing] = useState(false)
-  const [error, setError] = useState<Error>()
+  const [scanError, setScanError] = useState<ScanError>()
   const [devices, setDevices] = useState<Device[]>([])
 
-  const maybeAddDevice = useCallback(
-    (device: Device) => {
-      if (devices.some((i: Device) => i.id === device.id)) {
-        return
-      }
-
-      setDevices([...devices, device])
+  const setError = useCallback(
+    (error?: Error, kind: ScanErrorKind = 'unknown') => {
+      setScanError(error ? { error, kind } : undefined)
     },
-    [devices],
+    [],
   )
 
+  const maybeAddDevice = useCallback((device: Device) => {
+    setDevices((prev) =>
+      prev.some((i) => i.id === device.id) ? prev : [...prev, device],
+    )
+  }, [])
+
+  const stopScan = useCallback(() => {
+    clearTimeout(scanTimer.current)
+    scanTimer.current = undefined
+    scanSub.current?.unsubscribe()
+    scanSub.current = undefined
+    setRefreshing(false)
+  }, [])
+
   const startScan = useCallback(async () => {
+    stopScan()
     setRefreshing(true)
 
-    await checkPermission()
+    if (!(await checkPermission())) {
+      setRefreshing(false)
+      setError(new Error('Bluetooth permission not granted'), 'permission')
+      return
+    }
 
-    sub.current = new Observable<LedgerDetails>(TransportBLE.listen).subscribe({
+    // A concurrent startScan may have subscribed while we awaited permission
+    scanSub.current?.unsubscribe()
+    scanSub.current = TransportBLE.listen({
       complete: () => {
         setRefreshing(false)
       },
-      next: (e) => {
+      next: (e: DescriptorEvent<Device>) => {
         if (e.type === 'add') {
           maybeAddDevice(e.descriptor)
         }
@@ -106,55 +112,60 @@ const useDeviceScan = () => {
       error: (err) => {
         Logger.error(err)
         setError(err)
-        setRefreshing(false)
+        stopScan()
       },
     })
-  }, [maybeAddDevice])
+    scanTimer.current = setTimeout(stopScan, SCAN_TIMEOUT_MS)
+  }, [maybeAddDevice, setError, stopScan])
 
-  const reload = useCallback(() => {
-    if (sub.current) {
-      sub.current.unsubscribe()
-    }
-
-    setRefreshing(false)
-    startScan()
-  }, [startScan])
-
-  useAsync(async () => {
+  useEffect(() => {
     let previousAvailable: boolean | undefined
-    let isInitialState = true // Add this flag
 
-    new Observable<LedgerAvailable>(TransportBLE.observeState).subscribe(
-      (e) => {
-        if (e.available !== previousAvailable) {
-          // If this is the first state event, just record it without triggering errors
-          if (isInitialState) {
-            isInitialState = false
-            previousAvailable = e.available
-            if (e.available) {
-              reload()
-            }
-            return
-          }
+    // TransportBLE.observeState's unsubscribe is a no-op, so subscribe to the
+    // underlying manager directly to get a subscription we can remove.
+    stateSub.current = BlePlxManager.onStateChange((state: string) => {
+      if (state === 'Unknown' || state === 'Resetting') return
 
-          // Only trigger errors/actions for actual state changes after initialization
-          previousAvailable = e.available
-          if (e.available) {
-            reload()
-          } else if (!e.available && e.type) {
-            setError(new Error(e.type))
-          }
-        }
-      },
-    )
-    return () => {
-      if (sub.current) {
-        sub.current.unsubscribe()
+      const available = state === 'PoweredOn'
+      const isInitialState = previousAvailable === undefined
+      if (available === previousAvailable) return
+      previousAvailable = available
+
+      if (available) {
+        setScanError((prev) =>
+          prev?.kind === 'bluetoothOff' ? undefined : prev,
+        )
+        // The initial scan is started by the screen on focus
+        if (!isInitialState) startScan()
+        return
       }
-    }
-  }, [])
 
-  return { startScan, refreshing, error, devices, setError, reload }
+      if (state === 'PoweredOff') {
+        setError(new Error(state), 'bluetoothOff')
+      } else if (state === 'Unauthorized') {
+        setError(new Error(state), 'permission')
+      } else {
+        setError(new Error(state))
+      }
+    }, true)
+
+    return () => {
+      stateSub.current?.remove()
+      stateSub.current = undefined
+      stopScan()
+    }
+  }, [setError, startScan, stopScan])
+
+  return {
+    startScan,
+    stopScan,
+    refreshing,
+    error: scanError?.error,
+    errorKind: scanError?.kind,
+    devices,
+    setError,
+    reload: startScan,
+  }
 }
 
 export default useDeviceScan

--- a/src/hooks/useLedgerDeviceScan.tsx
+++ b/src/hooks/useLedgerDeviceScan.tsx
@@ -62,6 +62,12 @@ const useDeviceScan = () => {
   const scanSub = useRef<ScanSubscription | undefined>(undefined)
   const stateSub = useRef<BleSubscription | undefined>(undefined)
   const scanTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  // Bumped on every startScan so a stale permission await cannot subscribe
+  const scanGeneration = useRef(0)
+  // True between startScan and an explicit stopScan (blur, device selected).
+  // The scan timeout does not clear it, so Bluetooth coming back on restarts
+  // the scan only while the screen still wants one.
+  const scanWanted = useRef(false)
   const [refreshing, setRefreshing] = useState(false)
   const [scanError, setScanError] = useState<ScanError>()
   const [devices, setDevices] = useState<Device[]>([])
@@ -79,7 +85,7 @@ const useDeviceScan = () => {
     )
   }, [])
 
-  const stopScan = useCallback(() => {
+  const endScan = useCallback(() => {
     clearTimeout(scanTimer.current)
     scanTimer.current = undefined
     scanSub.current?.unsubscribe()
@@ -87,18 +93,26 @@ const useDeviceScan = () => {
     setRefreshing(false)
   }, [])
 
+  const stopScan = useCallback(() => {
+    scanWanted.current = false
+    endScan()
+  }, [endScan])
+
   const startScan = useCallback(async () => {
-    stopScan()
+    endScan()
+    scanWanted.current = true
+    scanGeneration.current += 1
+    const generation = scanGeneration.current
     setRefreshing(true)
 
-    if (!(await checkPermission())) {
+    const granted = await checkPermission()
+    if (generation !== scanGeneration.current) return
+    if (!granted) {
       setRefreshing(false)
       setError(new Error('Bluetooth permission not granted'), 'permission')
       return
     }
 
-    // A concurrent startScan may have subscribed while we awaited permission
-    scanSub.current?.unsubscribe()
     scanSub.current = TransportBLE.listen({
       complete: () => {
         setRefreshing(false)
@@ -115,8 +129,8 @@ const useDeviceScan = () => {
         stopScan()
       },
     })
-    scanTimer.current = setTimeout(stopScan, SCAN_TIMEOUT_MS)
-  }, [maybeAddDevice, setError, stopScan])
+    scanTimer.current = setTimeout(endScan, SCAN_TIMEOUT_MS)
+  }, [endScan, maybeAddDevice, setError, stopScan])
 
   useEffect(() => {
     let previousAvailable: boolean | undefined
@@ -136,7 +150,7 @@ const useDeviceScan = () => {
           prev?.kind === 'bluetoothOff' ? undefined : prev,
         )
         // The initial scan is started by the screen on focus
-        if (!isInitialState) startScan()
+        if (!isInitialState && scanWanted.current) startScan()
         return
       }
 
@@ -164,7 +178,6 @@ const useDeviceScan = () => {
     errorKind: scanError?.kind,
     devices,
     setError,
-    reload: startScan,
   }
 }
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -843,9 +843,6 @@ export default {
     enableBlindSign:
       'Please enable blind signing in the ledger solana app settings. This error can also occur if your ledger firmware is out of date.',
     signingFailed: 'Signing Failed',
-    transactionRejected: 'Transaction Rejected',
-    transactionRejectedDescription:
-      'You rejected the transaction on your Ledger device. If you meant to approve it, please try again.',
     chooseType: {
       bluetooth: {
         title: 'Bluetooth',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -858,6 +858,16 @@ export default {
       },
     },
     connectError: {
+      bluetoothOff: {
+        subtitle:
+          'Turn on Bluetooth in your phone settings to scan for your Ledger device.',
+        title: 'Bluetooth Is Off',
+      },
+      permission: {
+        subtitle:
+          'Allow Bluetooth access for this app in your phone settings so it can find your Ledger device.',
+        title: 'Bluetooth Permission Needed',
+      },
       steps: [
         'Check network connection',
         'Check Bluetooth is enabled',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -842,6 +842,7 @@ export default {
     pleaseEnterPinCode: 'Please enter pin code on your {{ device }}',
     enableBlindSign:
       'Please enable blind signing in the ledger solana app settings. This error can also occur if your ledger firmware is out of date.',
+    signingFailed: 'Signing Failed',
     transactionRejected: 'Transaction Rejected',
     transactionRejectedDescription:
       'You rejected the transaction on your Ledger device. If you meant to approve it, please try again.',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -837,6 +837,8 @@ export default {
     },
   },
   ledger: {
+    lookingForDevice:
+      'Looking for {{ device }}. Make sure it is unlocked and nearby.',
     openTheSolanaApp: 'Open the Solana app on your {{ device }}',
     pleaseConfirmTransaction: 'Please confirm transaction on your {{ device }}',
     pleaseEnterPinCode: 'Please enter pin code on your {{ device }}',

--- a/src/utils/__tests__/heliumLedger.test.ts
+++ b/src/utils/__tests__/heliumLedger.test.ts
@@ -1,0 +1,99 @@
+import {
+  CantOpenDevice,
+  DisconnectedDevice,
+  DisconnectedDeviceDuringOperation,
+  PairingFailed,
+  StatusCodes,
+  TransportStatusError,
+} from '@ledgerhq/errors'
+import { classifyLedgerError, isRetryableReconnectError } from '../heliumLedger'
+
+describe('classifyLedgerError', () => {
+  it('maps 0x6985 to userRejected', () => {
+    const err = new TransportStatusError(
+      StatusCodes.CONDITIONS_OF_USE_NOT_SATISFIED,
+    )
+    expect(classifyLedgerError(err)).toBe('userRejected')
+  })
+
+  it('maps 0x5515 to locked, including the LockedDeviceError subclass', () => {
+    const err = new TransportStatusError(StatusCodes.LOCKED_DEVICE)
+    expect(err.name).toBe('LockedDeviceError')
+    expect(classifyLedgerError(err)).toBe('locked')
+  })
+
+  it('maps 0x6d00 and 0x6e00 to appNotOpen', () => {
+    expect(
+      classifyLedgerError(
+        new TransportStatusError(StatusCodes.INS_NOT_SUPPORTED),
+      ),
+    ).toBe('appNotOpen')
+    expect(
+      classifyLedgerError(
+        new TransportStatusError(StatusCodes.CLA_NOT_SUPPORTED),
+      ),
+    ).toBe('appNotOpen')
+  })
+
+  it('maps the hw-app-solana blind sign message to blindSign', () => {
+    expect(
+      classifyLedgerError(
+        new Error(
+          'Missing a parameter. Try enabling blind signature in the app',
+        ),
+      ),
+    ).toBe('blindSign')
+  })
+
+  it('maps transport errors by name', () => {
+    expect(classifyLedgerError(new DisconnectedDevice())).toBe('transport')
+    expect(classifyLedgerError(new DisconnectedDeviceDuringOperation())).toBe(
+      'transport',
+    )
+    expect(classifyLedgerError(new CantOpenDevice())).toBe('transport')
+    expect(classifyLedgerError(new PairingFailed())).toBe('transport')
+  })
+
+  it('maps a connect timeout from ble-plx to transport', () => {
+    const bleError = Object.assign(new Error('Operation timed out'), {
+      errorCode: 3,
+    })
+    expect(classifyLedgerError(bleError)).toBe('transport')
+  })
+
+  it('maps anything else to unknown', () => {
+    expect(classifyLedgerError(new Error('boom'))).toBe('unknown')
+    expect(
+      classifyLedgerError(new TransportStatusError(StatusCodes.INCORRECT_DATA)),
+    ).toBe('unknown')
+    expect(classifyLedgerError(undefined)).toBe('unknown')
+    expect(classifyLedgerError('a string')).toBe('unknown')
+  })
+})
+
+describe('isRetryableReconnectError', () => {
+  it('retries disconnect and cant-open errors', () => {
+    expect(isRetryableReconnectError(new DisconnectedDevice())).toBe(true)
+    expect(
+      isRetryableReconnectError(new DisconnectedDeviceDuringOperation()),
+    ).toBe(true)
+    expect(isRetryableReconnectError(new CantOpenDevice())).toBe(true)
+  })
+
+  it('retries raw ble-plx errors', () => {
+    const bleError = Object.assign(new Error('Device was disconnected'), {
+      errorCode: 201,
+    })
+    expect(isRetryableReconnectError(bleError)).toBe(true)
+  })
+
+  it('does not retry status errors or pairing failures', () => {
+    expect(
+      isRetryableReconnectError(
+        new TransportStatusError(StatusCodes.LOCKED_DEVICE),
+      ),
+    ).toBe(false)
+    expect(isRetryableReconnectError(new PairingFailed())).toBe(false)
+    expect(isRetryableReconnectError(new Error('boom'))).toBe(false)
+  })
+})

--- a/src/utils/heliumLedger.ts
+++ b/src/utils/heliumLedger.ts
@@ -1,6 +1,7 @@
+import { StatusCodes } from '@ledgerhq/errors'
 import AppSolana from '@ledgerhq/hw-app-solana'
-import TransportBLE from '@ledgerhq/react-native-hw-transport-ble'
-import TransportHID from '@ledgerhq/react-native-hid'
+import type TransportBLE from '@ledgerhq/react-native-hw-transport-ble'
+import type TransportHID from '@ledgerhq/react-native-hid'
 
 export type DerivationType =
   | 'root'
@@ -51,38 +52,6 @@ const FALLBACK_ORDER: DerivationType[] = [
   'change',
 ]
 
-const cleanupTransport = async (
-  transport: TransportBLE | TransportHID,
-): Promise<void> => {
-  try {
-    // Send a cancel command to clear any pending operations
-    await transport.send(0x00, 0x00, 0x00, 0x00, Buffer.alloc(0))
-  } catch (error) {
-    // Ignore cleanup errors - they're expected if device is in weird state
-  }
-}
-
-const prepareTransportForSigning = async (
-  transport: TransportBLE | TransportHID,
-): Promise<void> => {
-  // Try multiple cleanup attempts to handle device lock/unlock scenarios
-  for (let i = 0; i < 3; i += 1) {
-    try {
-      await cleanupTransport(transport)
-      // Add a small delay to ensure cleanup takes effect
-      await new Promise((resolve) => setTimeout(resolve, 150))
-      break // Success, exit the loop
-    } catch (cleanupError) {
-      if (i === 2) {
-        // Last attempt failed, throw the error
-        throw cleanupError
-      }
-      // Wait longer between attempts
-      await new Promise((resolve) => setTimeout(resolve, 300))
-    }
-  }
-}
-
 export const getDerivationPath = (
   account = 0,
   type: DerivationType,
@@ -126,6 +95,88 @@ export const getDerivationPathLabel = (type: DerivationType): string => {
   return DERIVATION_LABELS[type] || 'Default'
 }
 
+export type LedgerErrorKind =
+  | 'userRejected'
+  | 'locked'
+  | 'appNotOpen'
+  | 'blindSign'
+  | 'transport'
+  | 'unknown'
+
+// Message thrown by @ledgerhq/hw-app-solana when blind signing is disabled.
+// The status word (0x6808) is swallowed by the library, so the message is the
+// only signal available.
+const BLIND_SIGN_MESSAGE =
+  'Missing a parameter. Try enabling blind signature in the app'
+
+const TRANSPORT_ERROR_NAMES = [
+  'DisconnectedDevice',
+  'DisconnectedDeviceDuringOperation',
+  'CantOpenDevice',
+  'PairingFailed',
+  'PeerRemovedPairing',
+  'TransportOpenUserCancelled',
+  'TransportExchangeTimeoutError',
+]
+
+const RETRYABLE_RECONNECT_NAMES = [
+  'DisconnectedDevice',
+  'DisconnectedDeviceDuringOperation',
+  'CantOpenDevice',
+]
+
+type ErrorLike = {
+  name?: string
+  message?: string
+  statusCode?: number
+  errorCode?: number
+}
+
+const asErrorLike = (error: unknown): ErrorLike | undefined =>
+  error && typeof error === 'object' ? (error as ErrorLike) : undefined
+
+// react-native-ble-plx errors carry a numeric errorCode and are not always
+// remapped by the ledger transport (for example a connect timeout).
+const isBleError = (error: ErrorLike) => typeof error.errorCode === 'number'
+
+export const classifyLedgerError = (error: unknown): LedgerErrorKind => {
+  const err = asErrorLike(error)
+  if (!err) return 'unknown'
+
+  switch (err.statusCode) {
+    case StatusCodes.CONDITIONS_OF_USE_NOT_SATISFIED:
+      return 'userRejected'
+    case StatusCodes.LOCKED_DEVICE:
+      return 'locked'
+    case StatusCodes.INS_NOT_SUPPORTED:
+    case StatusCodes.CLA_NOT_SUPPORTED:
+      return 'appNotOpen'
+    default:
+      break
+  }
+
+  if (err.message === BLIND_SIGN_MESSAGE) return 'blindSign'
+
+  if (
+    (err.name && TRANSPORT_ERROR_NAMES.includes(err.name)) ||
+    isBleError(err)
+  ) {
+    return 'transport'
+  }
+
+  return 'unknown'
+}
+
+// After the open-app APDU a Nano X drops and re-establishes BLE. During that
+// window connect attempts fail with disconnect / cannot-open errors that are
+// safe to retry.
+export const isRetryableReconnectError = (error: unknown): boolean => {
+  const err = asErrorLike(error)
+  if (!err) return false
+  if (err.name && RETRYABLE_RECONNECT_NAMES.includes(err.name)) return true
+  return isBleError(err)
+}
+
 const trySignWithFallbacks = async (
   solana: AppSolana,
   accountIndex: number,
@@ -148,9 +199,10 @@ const trySignWithFallbacks = async (
           const { signature } = await solana[signMethod](fallbackPath, buffer)
           return signature
         } catch (fallbackError) {
-          // If the fallback fails with 0x6985, it's user rejection
-          if (fallbackError?.toString().includes('0x6985')) {
-            throw new Error('User rejected transaction')
+          // A rejection on the device ends the flow. Rethrow the original so
+          // the caller can classify it by status code.
+          if (classifyLedgerError(fallbackError) === 'userRejected') {
+            throw fallbackError
           }
         }
       }
@@ -171,24 +223,13 @@ export const signLedgerTransaction = async (
   const primaryType =
     derivationType === true ? undefined : (derivationType as DerivationType)
 
-  try {
-    // Prepare transport for signing by cleaning up any stale state
-    await prepareTransportForSigning(transport)
-
-    return await trySignWithFallbacks(
-      solana,
-      accountIndex,
-      txBuffer,
-      'signTransaction',
-      primaryType,
-    )
-  } catch (error) {
-    // If we get a race condition, try to clean up transport and provide helpful error
-    if (error?.toString().includes('TransportRaceCondition')) {
-      await cleanupTransport(transport)
-    }
-    throw error
-  }
+  return trySignWithFallbacks(
+    solana,
+    accountIndex,
+    txBuffer,
+    'signTransaction',
+    primaryType,
+  )
 }
 
 export const signLedgerMessage = async (
@@ -202,24 +243,13 @@ export const signLedgerMessage = async (
   const primaryType =
     derivationType === true ? undefined : (derivationType as DerivationType)
 
-  try {
-    // Prepare transport for signing by cleaning up any stale state
-    await prepareTransportForSigning(transport)
-
-    return await trySignWithFallbacks(
-      solana,
-      accountIndex,
-      msgBuffer,
-      'signOffchainMessage',
-      primaryType,
-    )
-  } catch (error) {
-    // If we get a race condition, try to clean up transport and provide helpful error
-    if (error?.toString().includes('TransportRaceCondition')) {
-      await cleanupTransport(transport)
-    }
-    throw error
-  }
+  return trySignWithFallbacks(
+    solana,
+    accountIndex,
+    msgBuffer,
+    'signOffchainMessage',
+    primaryType,
+  )
 }
 
 export const getDerivationTypeForSigning = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4046,7 +4046,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/errors@npm:^6.24.0":
+"@ledgerhq/errors@npm:6.24.0, @ledgerhq/errors@npm:^6.24.0":
   version: 6.24.0
   resolution: "@ledgerhq/errors@npm:6.24.0"
   checksum: 10/9deba2af92746c4211273fe91cfa451f2f22c1006050d6d991fcaaf5ee3fb13a928d630dbbe276975f1716c055e10170f05afade5d210db39da26ebd78f8956b
@@ -13126,6 +13126,7 @@ __metadata:
     "@helium/wallet-link": "npm:^5.0.4"
     "@jup-ag/api": "npm:6.0.6"
     "@keystonehq/keystone-sdk": "npm:0.12.3"
+    "@ledgerhq/errors": "npm:6.24.0"
     "@ledgerhq/hw-app-solana": "npm:7.5.2"
     "@ledgerhq/hw-transport-mocker": "npm:6.29.8"
     "@ledgerhq/react-native-hid": "npm:6.32.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4075,7 +4075,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-transport@npm:^6.31.8, @ledgerhq/hw-transport@npm:^6.31.9":
+"@ledgerhq/hw-transport@npm:6.31.9, @ledgerhq/hw-transport@npm:^6.31.8, @ledgerhq/hw-transport@npm:^6.31.9":
   version: 6.31.9
   resolution: "@ledgerhq/hw-transport@npm:6.31.9"
   dependencies:
@@ -13128,6 +13128,7 @@ __metadata:
     "@keystonehq/keystone-sdk": "npm:0.12.3"
     "@ledgerhq/errors": "npm:6.24.0"
     "@ledgerhq/hw-app-solana": "npm:7.5.2"
+    "@ledgerhq/hw-transport": "npm:6.31.9"
     "@ledgerhq/hw-transport-mocker": "npm:6.29.8"
     "@ledgerhq/react-native-hid": "npm:6.32.9"
     "@ledgerhq/react-native-hw-transport-ble": "npm:6.35.2"


### PR DESCRIPTION
## Summary

Fixes the Ledger BLE signing and device-scan flows (tickets `.scratch/ledger-ble/issues/01` and `02`).

### Signing flow (`LedgerModal`, `useLedger`, `heliumLedger`)
- One signing session per `showLedgerModal` call, held in a ref. Retries settle that same promise. Module-level `promiseResolve`/`promiseReject` removed.
- Swipe-down, backdrop tap, Android back and the X button all go through `BottomSheetModal.onDismiss`, which rejects a still-pending session. Our own `dismiss()` after settling does not reject the next session.
- Errors are classified by `statusCode`/`name` (`classifyLedgerError`), not message strings: 0x6985 rejects and closes, 0x5515 shows the PIN screen, 0x6d00/0x6e00 during open-app means the app is already open, blind-sign shows the blind-sign screen, transport errors show Pairing Failed with retry, anything else shows a new `Signing Failed` state with the real message.
- After the open-app APDU: wait for the disconnect (or 1.5 s), reopen with up to 5 retries 1 s apart, and only proceed to sign once `getAppConfiguration` succeeds. Disconnect/cant-open errors are retryable only in that window.
- BLE transport is no longer kept in React state. `TransportBLE.open` is called each time with a 10 s timeout (the library caches by id). USB transport stays in a ref and is cleared on disconnect.
- Removed `cleanupTransport`/`prepareTransportForSigning`/`TransportRaceCondition` handling. `nano sp` is matched before `nano s`.

### Device scan (`useLedgerDeviceScan`, `DeviceScan`, manifest)
- Permission check awaits each permission in sequence, returns false, and shows a permission sheet instead of scanning. Android < 12 requests `ACCESS_FINE_LOCATION`; Android 12+ requests `BLUETOOTH_SCAN`/`BLUETOOTH_CONNECT`.
- `BLUETOOTH_SCAN` gets `android:usesPermissionFlags="neverForLocation"` (the merged manifest already had it from react-native-ble-plx, so the hotspot flow already runs with it).
- Scan and Bluetooth-state subscriptions live in refs and are torn down on unmount. Scan stops on blur, before navigating to `DeviceShow`, and after a 15 s timeout. Bluetooth turning back on restarts the scan only while the screen still wants one.
- Device list updates use the functional `setDevices` form with dedupe inside.
- Bluetooth off and Unauthorized map to their own sheet copy under `ledger.connectError`.
- `route.params.error` is cleared after it is consumed.

### Notes for reviewers
- `TransportBLE.observeState`'s unsubscribe is a no-op in this library version, so the hook subscribes through `BlePlxManager.onStateChange` directly.
- The reconnect-retryable set also includes raw ble-plx errors (numeric `errorCode`), bounded by the 5 attempts.
- `@ledgerhq/errors` and `@ledgerhq/hw-transport` were added as direct dependencies (they were already transitive) for the lint rule on extraneous imports.

## Test plan

- [x] `yarn lint`, `yarn test` (new unit tests for `classifyLedgerError` / `isRetryableReconnectError`)
- [ ] Real hardware, iOS and Android 12+: verification lists in both tickets (reject on device, swipe-down during signing, app closed on device, two Ledgers advertising, Bluetooth off then on, permission denied, back/forward to `DeviceShow` three times)
- [ ] Android 11 for the fine-location branch, if available
